### PR TITLE
Add GPT-5 image calculation

### DIFF
--- a/src/stores/ModelStore.js
+++ b/src/stores/ModelStore.js
@@ -1,6 +1,20 @@
 export const modelStore = (set, get) => ({
   models: [
     {
+      name: "GPT-5",
+      items: [
+        {
+          name: "GPT-5 (2025-08-07 - Global)",
+          tokensPerTile: 140,
+          maxImageDimension: 2048,
+          imageMinSizeLength: 768,
+          tileSizeLength: 512,
+          baseTokens: 70,
+          costPerMillionTokens: 1.25,
+        },
+      ],
+    },
+    {
       name: "GPT-4.1",
       items: [
         {


### PR DESCRIPTION
This PR introduces the GPT-5 model into the calculation.

Resolves #68 

This pull request also introduces enhancements to the `ImageEditor` component to improve the user experience when selecting and editing image presets, and adds a new model to the `modelStore`. The main changes include better handling of the "Custom" preset, improved input control for preset selection, and automatic updating of preset labels when image dimensions match a known preset.

**ModelStore update:**

* Added a new "GPT-5" model with its configuration to the `models` array in `modelStore`.

**ImageEditor improvements:**

* Added `useMemo` and `useState` hooks to manage preset options and input values, ensuring the "Custom" option is consistently available and input behavior is smoother. [[1]](diffhunk://#diff-7427af8390a44e1c165554069ab8aad3485600b29881a6af5e937f7eee098a18R14) [[2]](diffhunk://#diff-7427af8390a44e1c165554069ab8aad3485600b29881a6af5e937f7eee098a18R32-R40)
* Refactored the `Autocomplete` component to use the unified `allPresetOptions`, maintain input values per image, and reset the input when options are opened or changed. This prevents filtering out the "Custom" option and keeps the dropdown user-friendly.
* Updated the logic for changing image `height` or `width` so that if the new dimensions match a preset, the corresponding preset label is automatically selected; otherwise, the preset is set to "Custom". [[1]](diffhunk://#diff-7427af8390a44e1c165554069ab8aad3485600b29881a6af5e937f7eee098a18L78-R103) [[2]](diffhunk://#diff-7427af8390a44e1c165554069ab8aad3485600b29881a6af5e937f7eee098a18L90-R121)