### PR TITLE
feat: add model comparison mode

### DIFF
--- a/src/components/calculator/CalculationExplanation.jsx
+++ b/src/components/calculator/CalculationExplanation.jsx
@@ -9,6 +9,8 @@ import { useBoundStore } from "../../stores";
 
 export default function CalculationExplanation() {
   const model = useBoundStore((s) => s.model);
+  const comparisonMode = useBoundStore((s) => s.comparisonMode);
+  const comparisonResults = useBoundStore((s) => s.comparisonResults);
   const isPatch = model?.tokenizationType === "patch";
 
   return (
@@ -24,7 +26,35 @@ export default function CalculationExplanation() {
         </Typography>
       </AccordionSummary>
       <AccordionDetails>
-        {model ? (
+        {comparisonMode ? (
+          comparisonResults.length > 0 ? (
+            <Stack spacing={1.25}>
+              <Typography>
+                Each selected model calculates tokens independently against the
+                same set of images. Results are sorted by estimated cost
+                (cheapest first).
+              </Typography>
+              <Typography>
+                <b>Tile-based models</b> (GPT-4o, GPT-5, o1/o3): Images are
+                resized and divided into fixed-size tiles. Tokens = (tiles x
+                tokens per tile) + base tokens.
+              </Typography>
+              <Typography>
+                <b>Patch-based models</b> (GPT-5.2+, GPT-5.4, o4-mini): Images
+                are covered with patches and constrained by a patch budget.
+                Tokens = patches x token multiplier.
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Click a row in the comparison table to see the per-image
+                breakdown for that model.
+              </Typography>
+            </Stack>
+          ) : (
+            <Typography>
+              Select models and add images to see comparison results.
+            </Typography>
+          )
+        ) : model ? (
           isPatch ? (
             <Stack spacing={1.25} component="ol" sx={{ pl: 2 }}>
               <Typography component="li">

--- a/src/components/calculator/Calculator.jsx
+++ b/src/components/calculator/Calculator.jsx
@@ -38,9 +38,9 @@ export default function Calculator() {
           alignItems="center"
           justifyContent="space-between"
           flexWrap="wrap"
-          gap={1}
+          gap={2}
         >
-          <Typography variant="h5" fontWeight={700}>
+          <Typography variant="h5" fontWeight={700} sx={{ mr: "auto" }}>
             Configure your calculation
           </Typography>
           <ToggleButtonGroup

--- a/src/components/calculator/Calculator.jsx
+++ b/src/components/calculator/Calculator.jsx
@@ -3,11 +3,21 @@ import { useBoundStore } from "../../stores";
 import ModelSelector from "./ModelSelector";
 import ImageEditor from "./ImageEditor";
 import CalculatorOutput from "./CalculatorOutput";
-import { Box, Stack, Typography } from "@mui/material";
+import ComparisonTable from "./comparison/ComparisonTable";
+import {
+  Box,
+  Stack,
+  Typography,
+  ToggleButtonGroup,
+  ToggleButton,
+} from "@mui/material";
+import { Calculate, CompareArrows } from "@mui/icons-material";
 
 export default function Calculator() {
   const [modelName, setModelName] = useState("");
   const runCalculation = useBoundStore((s) => s.runCalculation);
+  const comparisonMode = useBoundStore((s) => s.comparisonMode);
+  const setComparisonMode = useBoundStore((s) => s.setComparisonMode);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -23,17 +33,46 @@ export default function Calculator() {
       aria-label="Calculator"
     >
       <Stack spacing={2} sx={{ mb: 2 }}>
-        <Typography variant="h5" fontWeight={700} gutterBottom>
-          Configure your calculation
-        </Typography>
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+          flexWrap="wrap"
+          gap={1}
+        >
+          <Typography variant="h5" fontWeight={700}>
+            Configure your calculation
+          </Typography>
+          <ToggleButtonGroup
+            value={comparisonMode ? "compare" : "single"}
+            exclusive
+            size="small"
+            onChange={(_, val) => {
+              if (val === null) return;
+              setComparisonMode(val === "compare");
+              setModelName("");
+            }}
+            aria-label="Calculator mode"
+          >
+            <ToggleButton value="single" aria-label="Single model">
+              <Calculate fontSize="small" sx={{ mr: 0.5 }} />
+              Single
+            </ToggleButton>
+            <ToggleButton value="compare" aria-label="Compare models">
+              <CompareArrows fontSize="small" sx={{ mr: 0.5 }} />
+              Compare
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </Stack>
         <Typography variant="body2" color="text.secondary">
-          Select a model and add one or more images to estimate input tokens and
-          cost for Azure OpenAI image processing.
+          {comparisonMode
+            ? "Select multiple models and add images to compare token costs side by side."
+            : "Select a model and add one or more images to estimate input tokens and cost for Azure OpenAI image processing."}
         </Typography>
       </Stack>
       <ModelSelector modelName={modelName} setModelName={setModelName} />
       <ImageEditor />
-      <CalculatorOutput />
+      {comparisonMode ? <ComparisonTable /> : <CalculatorOutput />}
     </Box>
   );
 }

--- a/src/components/calculator/Calculator.jsx
+++ b/src/components/calculator/Calculator.jsx
@@ -49,8 +49,16 @@ export default function Calculator() {
             size="small"
             onChange={(_, val) => {
               if (val === null) return;
-              setComparisonMode(val === "compare");
-              setModelName("");
+              const entering = val === "compare";
+              setComparisonMode(entering);
+              if (entering) {
+                // modelName stays as-is for UI; the store carries it into selectedModels
+                setModelName("");
+              } else {
+                // Read back the model the store picked when leaving comparison mode
+                const restored = useBoundStore.getState().model;
+                setModelName(restored?.name ?? "");
+              }
             }}
             aria-label="Calculator mode"
           >

--- a/src/components/calculator/CalculatorOutput.jsx
+++ b/src/components/calculator/CalculatorOutput.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Table,
   TableBody,
@@ -104,6 +104,26 @@ function ImageBreakdownList({ imageResults, isPatch }) {
   const [collapsedSet, setCollapsedSet] = useState(() =>
     defaultCollapsed ? new Set(validResults.map(({ idx }) => idx)) : new Set()
   );
+
+  // Reconcile when the set of valid images changes
+  const validIndices = validResults.map(({ idx }) => idx);
+  useEffect(() => {
+    setCollapsedSet((prev) => {
+      const validSet = new Set(validIndices);
+      // Remove indices that no longer exist
+      const pruned = new Set([...prev].filter((i) => validSet.has(i)));
+      // If we crossed the 3+ threshold, collapse any new entries
+      if (validIndices.length >= 3) {
+        for (const idx of validIndices) {
+          if (!pruned.has(idx) && !prev.has(idx)) {
+            // Truly new index (was not in prev at all, not just pruned)
+            pruned.add(idx);
+          }
+        }
+      }
+      return pruned;
+    });
+  }, [validIndices.join(",")]);
 
   const toggle = (i) =>
     setCollapsedSet((prev) => {

--- a/src/components/calculator/CalculatorOutput.jsx
+++ b/src/components/calculator/CalculatorOutput.jsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   Table,
   TableBody,
@@ -10,8 +11,16 @@ import {
   Box,
   Stack,
   Chip,
+  Collapse,
+  IconButton,
 } from "@mui/material";
+import {
+  BarChartOutlined,
+  ExpandMore,
+  ExpandLess,
+} from "@mui/icons-material";
 import { useBoundStore } from "../../stores";
+import ModelComment from "./comparison/ModelComment";
 
 export default function CalculatorOutput() {
   const totalTokens = useBoundStore((s) => s.totalTokens);
@@ -19,7 +28,16 @@ export default function CalculatorOutput() {
   const model = useBoundStore((s) => s.model);
   const imageResults = useBoundStore((s) => s.imageResults);
 
-  if (totalTokens === null) return null;
+  if (totalTokens === null) {
+    return (
+      <Box sx={{ mt: 4, textAlign: "center", py: 6, opacity: 0.5 }}>
+        <BarChartOutlined sx={{ fontSize: 48, mb: 1, color: "text.secondary" }} />
+        <Typography variant="body2" color="text.secondary">
+          Select a model and add images to see results
+        </Typography>
+      </Box>
+    );
+  }
 
   const isPatch = model?.tokenizationType === "patch";
 
@@ -35,7 +53,7 @@ export default function CalculatorOutput() {
       id="results"
       sx={(theme) => ({ mt: 4, scrollMarginTop: `calc(${theme.spacing(10)})` })}
     >
-      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
         <Typography variant="h6">Result</Typography>
         {model?.name && <Chip size="small" label={model.name} />}
         {model?.retirementDate && (
@@ -46,7 +64,11 @@ export default function CalculatorOutput() {
             variant="outlined"
           />
         )}
+        <ModelComment comment={model?.comment} />
       </Stack>
+      <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: "block" }}>
+        Results update as you change inputs
+      </Typography>
 
       {isPatch ? (
         <PatchSummary
@@ -64,49 +86,93 @@ export default function CalculatorOutput() {
         />
       )}
 
-      {imageResults.map((img, i) =>
-        img.resizedHeight ? (
-          <Box key={i} sx={{ mb: 2 }}>
-            <Typography variant="subtitle1" gutterBottom>
-              Image {i + 1}
-            </Typography>
-            <TableContainer component={Paper} variant="outlined">
-              <Table size="small" aria-label={`image ${i + 1} breakdown`}>
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Resized Size</TableCell>
-                    <TableCell>
-                      {isPatch ? "Patches (per image)" : "Tiles (per image)"}
-                    </TableCell>
-                    <TableCell>
-                      {isPatch ? "Total patches" : "Total tiles"}
-                    </TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  <TableRow>
-                    <TableCell>
-                      {img.resizedHeight} &times; {img.resizedWidth}
-                    </TableCell>
-                    <TableCell>
-                      {isPatch
-                        ? `${img.tokenization?.patchesHigh ?? 0} \u00d7 ${img.tokenization?.patchesWide ?? 0}`
-                        : `${img.tokenization?.tilesHigh ?? 0} \u00d7 ${img.tokenization?.tilesWide ?? 0}`}
-                    </TableCell>
-                    <TableCell>
-                      {isPatch
-                        ? img.tokenization?.totalPatches ?? 0
-                        : img.tokenization?.totalTiles ?? 0}
-                    </TableCell>
-                  </TableRow>
-                </TableBody>
-              </Table>
-            </TableContainer>
-          </Box>
-        ) : null
-      )}
+      <ImageBreakdownList imageResults={imageResults} isPatch={isPatch} />
     </Box>
   );
+}
+
+// ---------------------------------------------------------------------------
+// Per-image breakdown with collapsible rows
+// ---------------------------------------------------------------------------
+
+function ImageBreakdownList({ imageResults, isPatch }) {
+  const validResults = imageResults
+    .map((img, i) => ({ img, idx: i }))
+    .filter(({ img }) => img.resizedHeight);
+
+  const defaultCollapsed = validResults.length >= 3;
+  const [collapsedSet, setCollapsedSet] = useState(() =>
+    defaultCollapsed ? new Set(validResults.map(({ idx }) => idx)) : new Set()
+  );
+
+  const toggle = (i) =>
+    setCollapsedSet((prev) => {
+      const next = new Set(prev);
+      if (next.has(i)) next.delete(i);
+      else next.add(i);
+      return next;
+    });
+
+  return validResults.map(({ img, idx }) => {
+    const isCollapsed = collapsedSet.has(idx);
+    const meta = `${img.resizedHeight} \u00d7 ${img.resizedWidth} \u2022 ${img.tokenization?.imageTokens ?? 0} tokens`;
+
+    return (
+      <Box key={idx} sx={{ mb: 1 }}>
+        <Stack
+          direction="row"
+          alignItems="center"
+          spacing={0.5}
+          onClick={() => toggle(idx)}
+          sx={{ cursor: "pointer", userSelect: "none", py: 0.5 }}
+        >
+          <IconButton size="small" aria-expanded={!isCollapsed} aria-label={`Toggle image ${idx + 1} details`}>
+            {isCollapsed ? <ExpandMore fontSize="small" /> : <ExpandLess fontSize="small" />}
+          </IconButton>
+          <Typography variant="subtitle2">Image {idx + 1}</Typography>
+          {isCollapsed && (
+            <Typography variant="caption" color="text.secondary">
+              {meta}
+            </Typography>
+          )}
+        </Stack>
+        <Collapse in={!isCollapsed} timeout="auto" unmountOnExit>
+          <TableContainer component={Paper} variant="outlined" sx={{ mb: 1 }}>
+            <Table size="small" aria-label={`image ${idx + 1} breakdown`}>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Resized Size</TableCell>
+                  <TableCell>
+                    {isPatch ? "Patches (per image)" : "Tiles (per image)"}
+                  </TableCell>
+                  <TableCell>
+                    {isPatch ? "Total patches" : "Total tiles"}
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                <TableRow>
+                  <TableCell>
+                    {img.resizedHeight} &times; {img.resizedWidth}
+                  </TableCell>
+                  <TableCell>
+                    {isPatch
+                      ? `${img.tokenization?.patchesHigh ?? 0} \u00d7 ${img.tokenization?.patchesWide ?? 0}`
+                      : `${img.tokenization?.tilesHigh ?? 0} \u00d7 ${img.tokenization?.tilesWide ?? 0}`}
+                  </TableCell>
+                  <TableCell>
+                    {isPatch
+                      ? img.tokenization?.totalPatches ?? 0
+                      : img.tokenization?.totalTiles ?? 0}
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Collapse>
+      </Box>
+    );
+  });
 }
 
 function TileSummary({ model, imageResults, totalTokens, currency }) {

--- a/src/components/calculator/CalculatorOutput.jsx
+++ b/src/components/calculator/CalculatorOutput.jsx
@@ -106,8 +106,9 @@ function ImageBreakdownList({ imageResults, isPatch }) {
   );
 
   // Reconcile when the set of valid images changes
-  const validIndices = validResults.map(({ idx }) => idx);
+  const validIndicesKey = validResults.map(({ idx }) => idx).join(",");
   useEffect(() => {
+    const validIndices = validIndicesKey.split(",").filter(Boolean).map(Number);
     setCollapsedSet((prev) => {
       const validSet = new Set(validIndices);
       // Remove indices that no longer exist
@@ -116,14 +117,13 @@ function ImageBreakdownList({ imageResults, isPatch }) {
       if (validIndices.length >= 3) {
         for (const idx of validIndices) {
           if (!pruned.has(idx) && !prev.has(idx)) {
-            // Truly new index (was not in prev at all, not just pruned)
             pruned.add(idx);
           }
         }
       }
       return pruned;
     });
-  }, [validIndices.join(",")]);
+  }, [validIndicesKey]);
 
   const toggle = (i) =>
     setCollapsedSet((prev) => {

--- a/src/components/calculator/ImageEditor.jsx
+++ b/src/components/calculator/ImageEditor.jsx
@@ -79,7 +79,16 @@ export default function ImageEditor() {
     collapseAll();
   };
 
-  const syncCalculation = () => runCalculation();
+  const comparisonMode = useBoundStore((s) => s.comparisonMode);
+  const runComparison = useBoundStore((s) => s.runComparison);
+
+  const syncCalculation = () => {
+    if (comparisonMode) {
+      runComparison();
+    } else {
+      runCalculation();
+    }
+  };
 
   return (
     <Stack spacing={2}>

--- a/src/components/calculator/ModelSelector.jsx
+++ b/src/components/calculator/ModelSelector.jsx
@@ -1,10 +1,12 @@
 import {
   Autocomplete,
   Box,
+  Checkbox,
   Chip,
   TextField,
   Typography,
 } from "@mui/material";
+import { CheckBoxOutlineBlank, CheckBox } from "@mui/icons-material";
 import { useBoundStore } from "../../stores";
 
 export default function ModelSelector({ modelName, setModelName }) {
@@ -12,10 +14,91 @@ export default function ModelSelector({ modelName, setModelName }) {
   const setModel = useBoundStore((s) => s.setModel);
   const runCalculation = useBoundStore((s) => s.runCalculation);
   const resetCalculation = useBoundStore((s) => s.resetCalculation);
+  const comparisonMode = useBoundStore((s) => s.comparisonMode);
+  const selectedModels = useBoundStore((s) => s.selectedModels);
+  const toggleModelSelection = useBoundStore((s) => s.toggleModelSelection);
+  const runComparison = useBoundStore((s) => s.runComparison);
 
   const flatModels = models.flatMap((g) =>
     g.items.map((m) => ({ label: m.name, group: g.name, raw: m }))
   );
+
+  if (comparisonMode) {
+    const selectedLabels = new Set(selectedModels.map((m) => m.name));
+    const value = flatModels.filter((fm) => selectedLabels.has(fm.label));
+
+    return (
+      <Autocomplete
+        multiple
+        disableCloseOnSelect
+        options={flatModels}
+        groupBy={(option) => option.group}
+        getOptionLabel={(option) => option.label}
+        isOptionEqualToValue={(o, v) => o.label === v.label}
+        value={value}
+        onChange={(_, newValue, reason) => {
+          if (reason === "clear") {
+            selectedModels.forEach((m) => toggleModelSelection(m));
+            runComparison();
+            return;
+          }
+          // Compute diff to figure out which model was toggled
+          const newLabels = new Set(newValue.map((v) => v.label));
+          const added = newValue.find((v) => !selectedLabels.has(v.label));
+          const removed = [...selectedLabels].find((l) => !newLabels.has(l));
+          if (added) toggleModelSelection(added.raw);
+          if (removed) {
+            const model = selectedModels.find((m) => m.name === removed);
+            if (model) toggleModelSelection(model);
+          }
+          runComparison();
+        }}
+        renderOption={(props, option) => {
+          const checked = selectedLabels.has(option.label);
+          return (
+            <Box
+              component="li"
+              {...props}
+              key={option.label}
+              sx={{ display: "flex", alignItems: "center", gap: 1 }}
+            >
+              <Checkbox
+                icon={<CheckBoxOutlineBlank fontSize="small" />}
+                checkedIcon={<CheckBox fontSize="small" />}
+                checked={checked}
+                sx={{ p: 0, mr: 0.5 }}
+              />
+              <Typography variant="body2" noWrap>
+                {option.label}
+              </Typography>
+              {option.raw.retirementDate && (
+                <Chip
+                  label={`Retires ${option.raw.retirementDate}`}
+                  size="small"
+                  color="warning"
+                  variant="outlined"
+                  sx={{ ml: "auto", flexShrink: 0 }}
+                />
+              )}
+            </Box>
+          );
+        }}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label="Models"
+            placeholder={
+              selectedModels.length === 0
+                ? "Select models to compare..."
+                : ""
+            }
+            helperText="Pick multiple Azure OpenAI models to compare token costs"
+          />
+        )}
+        sx={{ mb: 2 }}
+      />
+    );
+  }
 
   return (
     <Autocomplete
@@ -59,7 +142,7 @@ export default function ModelSelector({ modelName, setModelName }) {
         <TextField
           {...params}
           label="Model"
-          placeholder="Search or choose a model…"
+          placeholder="Search or choose a model..."
           required
           helperText="Pick the Azure OpenAI model variant to estimate tokens and cost"
         />

--- a/src/components/calculator/ModelSelector.jsx
+++ b/src/components/calculator/ModelSelector.jsx
@@ -2,12 +2,12 @@ import {
   Autocomplete,
   Box,
   Checkbox,
-  Chip,
   TextField,
   Typography,
 } from "@mui/material";
 import { CheckBoxOutlineBlank, CheckBox } from "@mui/icons-material";
 import { useBoundStore } from "../../stores";
+import RetirementChip from "./comparison/RetirementChip";
 
 export default function ModelSelector({ modelName, setModelName }) {
   const models = useBoundStore((s) => s.models);
@@ -71,15 +71,7 @@ export default function ModelSelector({ modelName, setModelName }) {
               <Typography variant="body2" noWrap>
                 {option.label}
               </Typography>
-              {option.raw.retirementDate && (
-                <Chip
-                  label={`Retires ${option.raw.retirementDate}`}
-                  size="small"
-                  color="warning"
-                  variant="outlined"
-                  sx={{ ml: "auto", flexShrink: 0 }}
-                />
-              )}
+              <RetirementChip date={option.raw.retirementDate} sx={{ ml: "auto" }} />
             </Box>
           );
         }}
@@ -127,15 +119,7 @@ export default function ModelSelector({ modelName, setModelName }) {
           <Typography variant="body2" noWrap>
             {option.label}
           </Typography>
-          {option.raw.retirementDate && (
-            <Chip
-              label={`Retires ${option.raw.retirementDate}`}
-              size="small"
-              color="warning"
-              variant="outlined"
-              sx={{ ml: "auto", flexShrink: 0 }}
-            />
-          )}
+          <RetirementChip date={option.raw.retirementDate} sx={{ ml: "auto" }} />
         </Box>
       )}
       renderInput={(params) => (

--- a/src/components/calculator/comparison/ComparisonDetail.jsx
+++ b/src/components/calculator/comparison/ComparisonDetail.jsx
@@ -1,0 +1,53 @@
+import {
+  Box,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Typography,
+} from "@mui/material";
+
+export default function ComparisonDetail({ result }) {
+  if (!result?.imageResults?.length) return null;
+
+  const isPatch = result.model?.tokenizationType === "patch";
+
+  return (
+    <Box sx={{ px: 2, pb: 2 }}>
+      <Typography variant="subtitle2" gutterBottom>
+        Per-image breakdown for {result.model.name}
+      </Typography>
+      <TableContainer component={Paper} variant="outlined">
+        <Table size="small" aria-label="per-image breakdown">
+          <TableHead>
+            <TableRow>
+              <TableCell>Image</TableCell>
+              <TableCell>Resized Size</TableCell>
+              <TableCell>{isPatch ? "Patches" : "Tiles"}</TableCell>
+              <TableCell>Tokens</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {result.imageResults.map((img, i) => (
+              <TableRow key={i}>
+                <TableCell>{i + 1}</TableCell>
+                <TableCell>
+                  {img.resizedHeight} &times; {img.resizedWidth}
+                </TableCell>
+                <TableCell>
+                  {isPatch
+                    ? img.tokenization?.totalPatches ?? 0
+                    : img.tokenization?.totalTiles ?? 0}
+                </TableCell>
+                <TableCell>{img.tokenization?.imageTokens ?? 0}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+}

--- a/src/components/calculator/comparison/ComparisonRow.jsx
+++ b/src/components/calculator/comparison/ComparisonRow.jsx
@@ -1,0 +1,55 @@
+import { TableRow, TableCell, Collapse, Stack } from "@mui/material";
+import { ExpandMore, ExpandLess } from "@mui/icons-material";
+import RetirementChip from "./RetirementChip";
+import ModelComment from "./ModelComment";
+import ComparisonDetail from "./ComparisonDetail";
+
+const currencyFmt = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 5,
+});
+
+export default function ComparisonRow({ result, isExpanded, onToggle }) {
+  const { model, totalTokens, totalCost } = result;
+  const tokenizationType = model.tokenizationType === "patch" ? "Patch" : "Tile";
+
+  return (
+    <>
+      <TableRow
+        hover
+        onClick={onToggle}
+        sx={{ cursor: "pointer", "& > *": { borderBottom: isExpanded ? 0 : undefined } }}
+        aria-expanded={isExpanded}
+      >
+        <TableCell>
+          <Stack direction="row" alignItems="center" spacing={0.5}>
+            {isExpanded ? (
+              <ExpandLess fontSize="small" />
+            ) : (
+              <ExpandMore fontSize="small" />
+            )}
+            <span>{model.name}</span>
+            <ModelComment comment={model.comment} />
+          </Stack>
+        </TableCell>
+        <TableCell>{tokenizationType}</TableCell>
+        <TableCell align="right">{totalTokens.toLocaleString()}</TableCell>
+        <TableCell align="right">
+          {currencyFmt.format(Number(totalCost))}
+        </TableCell>
+        <TableCell>
+          <RetirementChip date={model.retirementDate} />
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell colSpan={5} sx={{ py: 0, px: 0 }}>
+          <Collapse in={isExpanded} timeout="auto" unmountOnExit>
+            <ComparisonDetail result={result} />
+          </Collapse>
+        </TableCell>
+      </TableRow>
+    </>
+  );
+}

--- a/src/components/calculator/comparison/ComparisonRow.jsx
+++ b/src/components/calculator/comparison/ComparisonRow.jsx
@@ -15,11 +15,21 @@ export default function ComparisonRow({ result, isExpanded, onToggle }) {
   const { model, totalTokens, totalCost } = result;
   const tokenizationType = model.tokenizationType === "patch" ? "Patch" : "Tile";
 
+  const handleKeyDown = (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onToggle();
+    }
+  };
+
   return (
     <>
       <TableRow
         hover
         onClick={onToggle}
+        onKeyDown={handleKeyDown}
+        tabIndex={0}
+        role="button"
         sx={{ cursor: "pointer", "& > *": { borderBottom: isExpanded ? 0 : undefined } }}
         aria-expanded={isExpanded}
       >

--- a/src/components/calculator/comparison/ComparisonTable.jsx
+++ b/src/components/calculator/comparison/ComparisonTable.jsx
@@ -11,6 +11,7 @@ import {
   Typography,
   Stack,
 } from "@mui/material";
+import { CompareArrowsOutlined } from "@mui/icons-material";
 import { useBoundStore } from "../../../stores";
 import ComparisonRow from "./ComparisonRow";
 
@@ -21,7 +22,16 @@ export default function ComparisonTable() {
   const sortOrder = useBoundStore((s) => s.comparisonSortOrder);
   const toggleSort = useBoundStore((s) => s.toggleComparisonSortOrder);
 
-  if (comparisonResults.length === 0) return null;
+  if (comparisonResults.length === 0) {
+    return (
+      <Box sx={{ mt: 4, textAlign: "center", py: 6, opacity: 0.5 }}>
+        <CompareArrowsOutlined sx={{ fontSize: 48, mb: 1, color: "text.secondary" }} />
+        <Typography variant="body2" color="text.secondary">
+          Select models and add images to compare results
+        </Typography>
+      </Box>
+    );
+  }
 
   return (
     <Box id="results" sx={(theme) => ({ mt: 4, scrollMarginTop: `calc(${theme.spacing(10)})` })}>

--- a/src/components/calculator/comparison/ComparisonTable.jsx
+++ b/src/components/calculator/comparison/ComparisonTable.jsx
@@ -6,6 +6,7 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  TableSortLabel,
   Paper,
   Typography,
   Stack,
@@ -17,6 +18,8 @@ export default function ComparisonTable() {
   const comparisonResults = useBoundStore((s) => s.comparisonResults);
   const expandedModelName = useBoundStore((s) => s.expandedModelName);
   const setExpandedModel = useBoundStore((s) => s.setExpandedModel);
+  const sortOrder = useBoundStore((s) => s.comparisonSortOrder);
+  const toggleSort = useBoundStore((s) => s.toggleComparisonSortOrder);
 
   if (comparisonResults.length === 0) return null;
 
@@ -25,8 +28,8 @@ export default function ComparisonTable() {
       <Stack spacing={1} sx={{ mb: 2 }}>
         <Typography variant="h6">Comparison Results</Typography>
         <Typography variant="body2" color="text.secondary">
-          Sorted by estimated cost (cheapest first). Click a row to see
-          per-image details.
+          Click the Estimated Cost header to toggle sort order. Click a row to
+          see per-image details.
         </Typography>
       </Stack>
       <TableContainer component={Paper} variant="outlined">
@@ -36,7 +39,15 @@ export default function ComparisonTable() {
               <TableCell>Model</TableCell>
               <TableCell>Tokenization</TableCell>
               <TableCell align="right">Total Tokens</TableCell>
-              <TableCell align="right">Estimated Cost</TableCell>
+              <TableCell align="right" sortDirection={sortOrder}>
+                <TableSortLabel
+                  active
+                  direction={sortOrder}
+                  onClick={toggleSort}
+                >
+                  Estimated Cost
+                </TableSortLabel>
+              </TableCell>
               <TableCell>Retirement</TableCell>
             </TableRow>
           </TableHead>

--- a/src/components/calculator/comparison/ComparisonTable.jsx
+++ b/src/components/calculator/comparison/ComparisonTable.jsx
@@ -1,0 +1,57 @@
+import {
+  Box,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Typography,
+  Stack,
+} from "@mui/material";
+import { useBoundStore } from "../../../stores";
+import ComparisonRow from "./ComparisonRow";
+
+export default function ComparisonTable() {
+  const comparisonResults = useBoundStore((s) => s.comparisonResults);
+  const expandedModelName = useBoundStore((s) => s.expandedModelName);
+  const setExpandedModel = useBoundStore((s) => s.setExpandedModel);
+
+  if (comparisonResults.length === 0) return null;
+
+  return (
+    <Box id="results" sx={(theme) => ({ mt: 4, scrollMarginTop: `calc(${theme.spacing(10)})` })}>
+      <Stack spacing={1} sx={{ mb: 2 }}>
+        <Typography variant="h6">Comparison Results</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Sorted by estimated cost (cheapest first). Click a row to see
+          per-image details.
+        </Typography>
+      </Stack>
+      <TableContainer component={Paper} variant="outlined">
+        <Table size="small" aria-label="model comparison results">
+          <TableHead>
+            <TableRow>
+              <TableCell>Model</TableCell>
+              <TableCell>Tokenization</TableCell>
+              <TableCell align="right">Total Tokens</TableCell>
+              <TableCell align="right">Estimated Cost</TableCell>
+              <TableCell>Retirement</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {comparisonResults.map((result) => (
+              <ComparisonRow
+                key={result.model.name}
+                result={result}
+                isExpanded={expandedModelName === result.model.name}
+                onToggle={() => setExpandedModel(result.model.name)}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+}

--- a/src/components/calculator/comparison/ModelComment.jsx
+++ b/src/components/calculator/comparison/ModelComment.jsx
@@ -1,0 +1,13 @@
+import { Tooltip, IconButton } from "@mui/material";
+import { InfoOutlined } from "@mui/icons-material";
+
+export default function ModelComment({ comment }) {
+  if (!comment) return null;
+  return (
+    <Tooltip title={comment} arrow placement="top">
+      <IconButton size="small" aria-label="Model note" sx={{ ml: 0.5 }}>
+        <InfoOutlined fontSize="small" color="action" />
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/src/components/calculator/comparison/RetirementChip.jsx
+++ b/src/components/calculator/comparison/RetirementChip.jsx
@@ -1,6 +1,6 @@
 import { Chip } from "@mui/material";
 
-export default function RetirementChip({ date }) {
+export default function RetirementChip({ date, sx }) {
   if (!date) return null;
   return (
     <Chip
@@ -8,7 +8,7 @@ export default function RetirementChip({ date }) {
       size="small"
       color="warning"
       variant="outlined"
-      sx={{ flexShrink: 0 }}
+      sx={{ flexShrink: 0, ...sx }}
     />
   );
 }

--- a/src/components/calculator/comparison/RetirementChip.jsx
+++ b/src/components/calculator/comparison/RetirementChip.jsx
@@ -1,0 +1,14 @@
+import { Chip } from "@mui/material";
+
+export default function RetirementChip({ date }) {
+  if (!date) return null;
+  return (
+    <Chip
+      label={`Retires ${date}`}
+      size="small"
+      color="warning"
+      variant="outlined"
+      sx={{ flexShrink: 0 }}
+    />
+  );
+}

--- a/src/stores/ComparisonStore.js
+++ b/src/stores/ComparisonStore.js
@@ -21,12 +21,18 @@ export const comparisonStore = (set, get) => ({
         expandedModelName: null,
         comparisonSortOrder: "asc",
       });
+      // Auto-calculate if there are images and a carried-over model
+      if (carryOver.length > 0 && state.images.length > 0) {
+        get().runComparison();
+      }
     } else {
-      // Compare -> Single: pick the cheapest result or the first selected model
-      const cheapest =
-        state.comparisonResults.length > 0
-          ? state.comparisonResults[0].model
-          : state.selectedModels[0] ?? null;
+      // Compare -> Single: find the actual cheapest regardless of display sort
+      let cheapest = state.selectedModels[0] ?? null;
+      if (state.comparisonResults.length > 0) {
+        cheapest = state.comparisonResults.reduce((min, r) =>
+          Number(r.totalCost) < Number(min.totalCost) ? r : min
+        ).model;
+      }
       set({
         comparisonMode: false,
         selectedModels: [],
@@ -35,6 +41,12 @@ export const comparisonStore = (set, get) => ({
         comparisonSortOrder: "asc",
         model: cheapest ?? "",
       });
+      // Auto-calculate single-mode results for the restored model
+      if (cheapest && state.images.length > 0) {
+        get().runCalculation();
+      } else {
+        get().resetCalculation();
+      }
     }
   },
 
@@ -65,7 +77,7 @@ export const comparisonStore = (set, get) => ({
   runComparison: () => {
     const { selectedModels, images, comparisonSortOrder } = get();
     if (selectedModels.length === 0 || images.length === 0) {
-      set({ comparisonResults: [] });
+      set({ comparisonResults: [], expandedModelName: null });
       return;
     }
 

--- a/src/stores/ComparisonStore.js
+++ b/src/stores/ComparisonStore.js
@@ -5,14 +5,37 @@ export const comparisonStore = (set, get) => ({
   selectedModels: [],
   comparisonResults: [],
   expandedModelName: null,
+  comparisonSortOrder: "asc",
 
   setComparisonMode: (enabled) => {
-    set({
-      comparisonMode: enabled,
-      selectedModels: [],
-      comparisonResults: [],
-      expandedModelName: null,
-    });
+    const state = get();
+
+    if (enabled) {
+      // Single -> Compare: carry over the current single model
+      const carryOver =
+        state.model && typeof state.model === "object" ? [state.model] : [];
+      set({
+        comparisonMode: true,
+        selectedModels: carryOver,
+        comparisonResults: [],
+        expandedModelName: null,
+        comparisonSortOrder: "asc",
+      });
+    } else {
+      // Compare -> Single: pick the cheapest result or the first selected model
+      const cheapest =
+        state.comparisonResults.length > 0
+          ? state.comparisonResults[0].model
+          : state.selectedModels[0] ?? null;
+      set({
+        comparisonMode: false,
+        selectedModels: [],
+        comparisonResults: [],
+        expandedModelName: null,
+        comparisonSortOrder: "asc",
+        model: cheapest ?? "",
+      });
+    }
   },
 
   toggleModelSelection: (model) => {
@@ -28,8 +51,19 @@ export const comparisonStore = (set, get) => ({
     set({ selectedModels: [], comparisonResults: [], expandedModelName: null });
   },
 
+  toggleComparisonSortOrder: () => {
+    const state = get();
+    const next = state.comparisonSortOrder === "asc" ? "desc" : "asc";
+    const sorted = [...state.comparisonResults].sort((a, b) =>
+      next === "asc"
+        ? Number(a.totalCost) - Number(b.totalCost)
+        : Number(b.totalCost) - Number(a.totalCost)
+    );
+    set({ comparisonSortOrder: next, comparisonResults: sorted });
+  },
+
   runComparison: () => {
-    const { selectedModels, images } = get();
+    const { selectedModels, images, comparisonSortOrder } = get();
     if (selectedModels.length === 0 || images.length === 0) {
       set({ comparisonResults: [] });
       return;
@@ -43,7 +77,11 @@ export const comparisonStore = (set, get) => ({
       return { model, totalTokens, totalCost, imageResults };
     });
 
-    results.sort((a, b) => Number(a.totalCost) - Number(b.totalCost));
+    results.sort((a, b) =>
+      comparisonSortOrder === "asc"
+        ? Number(a.totalCost) - Number(b.totalCost)
+        : Number(b.totalCost) - Number(a.totalCost)
+    );
     set({ comparisonResults: results });
   },
 

--- a/src/stores/ComparisonStore.js
+++ b/src/stores/ComparisonStore.js
@@ -1,0 +1,55 @@
+import { calculateForModel } from "./CalcStore";
+
+export const comparisonStore = (set, get) => ({
+  comparisonMode: false,
+  selectedModels: [],
+  comparisonResults: [],
+  expandedModelName: null,
+
+  setComparisonMode: (enabled) => {
+    set({
+      comparisonMode: enabled,
+      selectedModels: [],
+      comparisonResults: [],
+      expandedModelName: null,
+    });
+  },
+
+  toggleModelSelection: (model) => {
+    const current = get().selectedModels;
+    const exists = current.some((m) => m.name === model.name);
+    const next = exists
+      ? current.filter((m) => m.name !== model.name)
+      : [...current, model];
+    set({ selectedModels: next });
+  },
+
+  clearSelectedModels: () => {
+    set({ selectedModels: [], comparisonResults: [], expandedModelName: null });
+  },
+
+  runComparison: () => {
+    const { selectedModels, images } = get();
+    if (selectedModels.length === 0 || images.length === 0) {
+      set({ comparisonResults: [] });
+      return;
+    }
+
+    const results = selectedModels.map((model) => {
+      const { totalTokens, totalCost, imageResults } = calculateForModel(
+        model,
+        images
+      );
+      return { model, totalTokens, totalCost, imageResults };
+    });
+
+    results.sort((a, b) => Number(a.totalCost) - Number(b.totalCost));
+    set({ comparisonResults: results });
+  },
+
+  setExpandedModel: (name) => {
+    set((state) => ({
+      expandedModelName: state.expandedModelName === name ? null : name,
+    }));
+  },
+});

--- a/src/stores/__tests__/ComparisonStore.test.js
+++ b/src/stores/__tests__/ComparisonStore.test.js
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useBoundStore } from "../index";
+
+// Helper: reset the store between tests
+function resetStore() {
+  useBoundStore.setState({
+    comparisonMode: false,
+    selectedModels: [],
+    comparisonResults: [],
+    expandedModelName: null,
+    images: [],
+    model: "",
+    imageResults: [],
+    totalTokens: null,
+    totalCost: null,
+  });
+}
+
+const tileModel = {
+  name: "GPT-5 (Global)",
+  tokensPerTile: 140,
+  maxImageDimension: 2048,
+  imageMinSizeLength: 768,
+  tileSizeLength: 512,
+  baseTokens: 70,
+  costPerMillionTokens: 1.25,
+};
+
+const patchModelCheap = {
+  name: "GPT-5.4 mini (Global)",
+  tokenizationType: "patch",
+  patchSize: 32,
+  patchBudget: 1536,
+  tokenMultiplier: 1.62,
+  maxImageDimension: 2048,
+  costPerMillionTokens: 0.75,
+};
+
+const patchModelExpensive = {
+  name: "GPT-5.4 (Global)",
+  tokenizationType: "patch",
+  patchSize: 32,
+  patchBudget: 2500,
+  tokenMultiplier: 1.0,
+  maxImageDimension: 2048,
+  costPerMillionTokens: 2.5,
+};
+
+describe("ComparisonStore", () => {
+  beforeEach(resetStore);
+
+  // -----------------------------------------------------------------------
+  // setComparisonMode
+  // -----------------------------------------------------------------------
+
+  describe("setComparisonMode", () => {
+    it("enables comparison mode", () => {
+      useBoundStore.getState().setComparisonMode(true);
+      expect(useBoundStore.getState().comparisonMode).toBe(true);
+    });
+
+    it("disabling comparison mode clears selections and results", () => {
+      const s = useBoundStore.getState();
+      s.setComparisonMode(true);
+      s.toggleModelSelection(tileModel);
+      s.addImage({ height: 1024, width: 1024, multiplier: 1 });
+      s.runComparison();
+      expect(useBoundStore.getState().comparisonResults.length).toBe(1);
+
+      useBoundStore.getState().setComparisonMode(false);
+      const state = useBoundStore.getState();
+      expect(state.comparisonMode).toBe(false);
+      expect(state.selectedModels).toEqual([]);
+      expect(state.comparisonResults).toEqual([]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // toggleModelSelection
+  // -----------------------------------------------------------------------
+
+  describe("toggleModelSelection", () => {
+    it("adds a model to the selection", () => {
+      useBoundStore.getState().toggleModelSelection(tileModel);
+      expect(useBoundStore.getState().selectedModels).toHaveLength(1);
+      expect(useBoundStore.getState().selectedModels[0].name).toBe(
+        tileModel.name
+      );
+    });
+
+    it("removes a model when toggled again", () => {
+      const s = useBoundStore.getState();
+      s.toggleModelSelection(tileModel);
+      s.toggleModelSelection(tileModel);
+      expect(useBoundStore.getState().selectedModels).toHaveLength(0);
+    });
+
+    it("supports multiple selections", () => {
+      const s = useBoundStore.getState();
+      s.toggleModelSelection(tileModel);
+      s.toggleModelSelection(patchModelCheap);
+      expect(useBoundStore.getState().selectedModels).toHaveLength(2);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // clearSelectedModels
+  // -----------------------------------------------------------------------
+
+  describe("clearSelectedModels", () => {
+    it("clears all selected models and results", () => {
+      const s = useBoundStore.getState();
+      s.toggleModelSelection(tileModel);
+      s.addImage({ height: 1024, width: 1024, multiplier: 1 });
+      s.runComparison();
+      expect(useBoundStore.getState().comparisonResults.length).toBe(1);
+
+      useBoundStore.getState().clearSelectedModels();
+      const state = useBoundStore.getState();
+      expect(state.selectedModels).toEqual([]);
+      expect(state.comparisonResults).toEqual([]);
+      expect(state.expandedModelName).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // runComparison
+  // -----------------------------------------------------------------------
+
+  describe("runComparison", () => {
+    it("produces results for each selected model", () => {
+      const s = useBoundStore.getState();
+      s.toggleModelSelection(tileModel);
+      s.toggleModelSelection(patchModelCheap);
+      s.addImage({ height: 1024, width: 1024, multiplier: 1 });
+      s.runComparison();
+
+      const results = useBoundStore.getState().comparisonResults;
+      expect(results).toHaveLength(2);
+      results.forEach((r) => {
+        expect(r).toHaveProperty("model");
+        expect(r).toHaveProperty("totalTokens");
+        expect(r).toHaveProperty("totalCost");
+        expect(r).toHaveProperty("imageResults");
+      });
+    });
+
+    it("sorts results by cost ascending (cheapest first)", () => {
+      const s = useBoundStore.getState();
+      s.toggleModelSelection(patchModelExpensive);
+      s.toggleModelSelection(patchModelCheap);
+      s.toggleModelSelection(tileModel);
+      s.addImage({ height: 1024, width: 1024, multiplier: 1 });
+      s.runComparison();
+
+      const results = useBoundStore.getState().comparisonResults;
+      for (let i = 1; i < results.length; i++) {
+        expect(Number(results[i].totalCost)).toBeGreaterThanOrEqual(
+          Number(results[i - 1].totalCost)
+        );
+      }
+    });
+
+    it("returns empty results when no models are selected", () => {
+      const s = useBoundStore.getState();
+      s.addImage({ height: 1024, width: 1024, multiplier: 1 });
+      s.runComparison();
+      expect(useBoundStore.getState().comparisonResults).toEqual([]);
+    });
+
+    it("returns empty results when no images exist", () => {
+      const s = useBoundStore.getState();
+      s.toggleModelSelection(tileModel);
+      s.runComparison();
+      expect(useBoundStore.getState().comparisonResults).toEqual([]);
+    });
+
+    it("recalculates when images change", () => {
+      const s = useBoundStore.getState();
+      s.toggleModelSelection(tileModel);
+      s.addImage({ height: 1024, width: 1024, multiplier: 1 });
+      s.runComparison();
+      const firstTokens =
+        useBoundStore.getState().comparisonResults[0].totalTokens;
+
+      useBoundStore
+        .getState()
+        .addImage({ height: 2048, width: 2048, multiplier: 1 });
+      useBoundStore.getState().runComparison();
+      const secondTokens =
+        useBoundStore.getState().comparisonResults[0].totalTokens;
+
+      expect(secondTokens).toBeGreaterThan(firstTokens);
+    });
+
+    it("does not mutate the images array", () => {
+      const s = useBoundStore.getState();
+      s.addImage({ height: 1024, width: 1024, multiplier: 1 });
+      s.addImage({ height: 2000, width: 100, multiplier: 2 });
+      s.toggleModelSelection(tileModel);
+      s.toggleModelSelection(patchModelCheap);
+
+      const imagesBefore = JSON.parse(
+        JSON.stringify(useBoundStore.getState().images)
+      );
+      useBoundStore.getState().runComparison();
+      expect(useBoundStore.getState().images).toEqual(imagesBefore);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // setExpandedModel
+  // -----------------------------------------------------------------------
+
+  describe("setExpandedModel", () => {
+    it("sets the expanded model name", () => {
+      useBoundStore.getState().setExpandedModel("GPT-5 (Global)");
+      expect(useBoundStore.getState().expandedModelName).toBe(
+        "GPT-5 (Global)"
+      );
+    });
+
+    it("toggles off when called with the same name", () => {
+      const s = useBoundStore.getState();
+      s.setExpandedModel("GPT-5 (Global)");
+      s.setExpandedModel("GPT-5 (Global)");
+      expect(useBoundStore.getState().expandedModelName).toBeNull();
+    });
+  });
+});

--- a/src/stores/__tests__/ComparisonStore.test.js
+++ b/src/stores/__tests__/ComparisonStore.test.js
@@ -8,6 +8,7 @@ function resetStore() {
     selectedModels: [],
     comparisonResults: [],
     expandedModelName: null,
+    comparisonSortOrder: "asc",
     images: [],
     model: "",
     imageResults: [],
@@ -72,6 +73,72 @@ describe("ComparisonStore", () => {
       expect(state.comparisonMode).toBe(false);
       expect(state.selectedModels).toEqual([]);
       expect(state.comparisonResults).toEqual([]);
+    });
+
+    it("carries the single model into selectedModels when entering comparison mode", () => {
+      useBoundStore.setState({ model: tileModel });
+      useBoundStore.getState().setComparisonMode(true);
+      const state = useBoundStore.getState();
+      expect(state.comparisonMode).toBe(true);
+      expect(state.selectedModels).toHaveLength(1);
+      expect(state.selectedModels[0].name).toBe(tileModel.name);
+    });
+
+    it("does not carry over when there is no single model selected", () => {
+      useBoundStore.setState({ model: "" });
+      useBoundStore.getState().setComparisonMode(true);
+      expect(useBoundStore.getState().selectedModels).toHaveLength(0);
+    });
+
+    it("restores the cheapest model as the single model when leaving comparison mode", () => {
+      const s = useBoundStore.getState();
+      s.setComparisonMode(true);
+      s.toggleModelSelection(patchModelExpensive);
+      s.toggleModelSelection(patchModelCheap);
+      s.addImage({ height: 1024, width: 1024, multiplier: 1 });
+      s.runComparison();
+
+      // The cheapest should be patchModelCheap (costPerMillionTokens: 0.75)
+      useBoundStore.getState().setComparisonMode(false);
+      const state = useBoundStore.getState();
+      expect(state.comparisonMode).toBe(false);
+      expect(state.model.name).toBe(patchModelCheap.name);
+    });
+
+    it("restores the first selected model when leaving comparison mode with no results", () => {
+      const s = useBoundStore.getState();
+      s.setComparisonMode(true);
+      s.toggleModelSelection(patchModelExpensive);
+      s.toggleModelSelection(tileModel);
+      // No images, so no results
+
+      useBoundStore.getState().setComparisonMode(false);
+      const state = useBoundStore.getState();
+      expect(state.model.name).toBe(patchModelExpensive.name);
+    });
+
+    it("leaves model empty when leaving comparison mode with nothing selected", () => {
+      useBoundStore.getState().setComparisonMode(true);
+      // Nothing selected, no results
+      useBoundStore.getState().setComparisonMode(false);
+      expect(useBoundStore.getState().model).toBe("");
+    });
+
+    it("resets sort order when switching modes", () => {
+      const s = useBoundStore.getState();
+      s.setComparisonMode(true);
+      s.toggleModelSelection(patchModelExpensive);
+      s.toggleModelSelection(patchModelCheap);
+      s.addImage({ height: 1024, width: 1024, multiplier: 1 });
+      s.runComparison();
+      s.toggleComparisonSortOrder();
+      expect(useBoundStore.getState().comparisonSortOrder).toBe("desc");
+
+      useBoundStore.getState().setComparisonMode(false);
+      expect(useBoundStore.getState().comparisonSortOrder).toBe("asc");
+
+      useBoundStore.getState().setComparisonMode(true);
+      expect(useBoundStore.getState().comparisonSortOrder).toBe("asc");
     });
   });
 
@@ -225,6 +292,66 @@ describe("ComparisonStore", () => {
       s.setExpandedModel("GPT-5 (Global)");
       s.setExpandedModel("GPT-5 (Global)");
       expect(useBoundStore.getState().expandedModelName).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // toggleComparisonSortOrder
+  // -----------------------------------------------------------------------
+
+  describe("toggleComparisonSortOrder", () => {
+    it("defaults to ascending sort order", () => {
+      expect(useBoundStore.getState().comparisonSortOrder).toBe("asc");
+    });
+
+    it("toggles from ascending to descending", () => {
+      const s = useBoundStore.getState();
+      s.toggleModelSelection(patchModelExpensive);
+      s.toggleModelSelection(patchModelCheap);
+      s.addImage({ height: 1024, width: 1024, multiplier: 1 });
+      s.runComparison();
+
+      useBoundStore.getState().toggleComparisonSortOrder();
+      const state = useBoundStore.getState();
+      expect(state.comparisonSortOrder).toBe("desc");
+      // Most expensive should be first
+      expect(Number(state.comparisonResults[0].totalCost)).toBeGreaterThanOrEqual(
+        Number(state.comparisonResults[1].totalCost)
+      );
+    });
+
+    it("toggles back from descending to ascending", () => {
+      const s = useBoundStore.getState();
+      s.toggleModelSelection(patchModelExpensive);
+      s.toggleModelSelection(patchModelCheap);
+      s.addImage({ height: 1024, width: 1024, multiplier: 1 });
+      s.runComparison();
+
+      useBoundStore.getState().toggleComparisonSortOrder();
+      useBoundStore.getState().toggleComparisonSortOrder();
+      const state = useBoundStore.getState();
+      expect(state.comparisonSortOrder).toBe("asc");
+      expect(Number(state.comparisonResults[0].totalCost)).toBeLessThanOrEqual(
+        Number(state.comparisonResults[1].totalCost)
+      );
+    });
+
+    it("preserves sort order across runComparison calls", () => {
+      const s = useBoundStore.getState();
+      s.toggleModelSelection(patchModelExpensive);
+      s.toggleModelSelection(patchModelCheap);
+      s.addImage({ height: 1024, width: 1024, multiplier: 1 });
+      s.runComparison();
+      s.toggleComparisonSortOrder();
+      expect(useBoundStore.getState().comparisonSortOrder).toBe("desc");
+
+      // Re-run comparison (simulates image change)
+      useBoundStore.getState().runComparison();
+      const state = useBoundStore.getState();
+      expect(state.comparisonSortOrder).toBe("desc");
+      expect(Number(state.comparisonResults[0].totalCost)).toBeGreaterThanOrEqual(
+        Number(state.comparisonResults[1].totalCost)
+      );
     });
   });
 });

--- a/src/stores/__tests__/ComparisonStore.test.js
+++ b/src/stores/__tests__/ComparisonStore.test.js
@@ -105,6 +105,24 @@ describe("ComparisonStore", () => {
       expect(state.model.name).toBe(patchModelCheap.name);
     });
 
+    it("restores the cheapest model even when sort order is descending", () => {
+      const s = useBoundStore.getState();
+      s.setComparisonMode(true);
+      s.toggleModelSelection(patchModelExpensive);
+      s.toggleModelSelection(patchModelCheap);
+      s.addImage({ height: 1024, width: 1024, multiplier: 1 });
+      s.runComparison();
+      // Flip to descending so [0] is the most expensive
+      s.toggleComparisonSortOrder();
+      expect(useBoundStore.getState().comparisonResults[0].model.name).toBe(
+        patchModelExpensive.name
+      );
+
+      useBoundStore.getState().setComparisonMode(false);
+      // Should still pick the cheapest, not the first in display order
+      expect(useBoundStore.getState().model.name).toBe(patchModelCheap.name);
+    });
+
     it("restores the first selected model when leaving comparison mode with no results", () => {
       const s = useBoundStore.getState();
       s.setComparisonMode(true);
@@ -139,6 +157,46 @@ describe("ComparisonStore", () => {
 
       useBoundStore.getState().setComparisonMode(true);
       expect(useBoundStore.getState().comparisonSortOrder).toBe("asc");
+    });
+
+    it("auto-runs comparison when entering comparison mode with a model and images", () => {
+      useBoundStore.setState({ model: tileModel });
+      useBoundStore.getState().addImage({ height: 1024, width: 1024, multiplier: 1 });
+      useBoundStore.getState().setComparisonMode(true);
+      const state = useBoundStore.getState();
+      expect(state.comparisonResults).toHaveLength(1);
+      expect(state.comparisonResults[0].model.name).toBe(tileModel.name);
+      expect(state.comparisonResults[0].totalTokens).toBeGreaterThan(0);
+    });
+
+    it("does not auto-run comparison when entering with no images", () => {
+      useBoundStore.setState({ model: tileModel });
+      useBoundStore.getState().setComparisonMode(true);
+      expect(useBoundStore.getState().comparisonResults).toHaveLength(0);
+    });
+
+    it("auto-runs single calculation when leaving comparison mode with a restored model and images", () => {
+      const s = useBoundStore.getState();
+      s.addImage({ height: 1024, width: 1024, multiplier: 1 });
+      s.setComparisonMode(true);
+      s.toggleModelSelection(patchModelCheap);
+      s.runComparison();
+
+      useBoundStore.getState().setComparisonMode(false);
+      const state = useBoundStore.getState();
+      expect(state.model.name).toBe(patchModelCheap.name);
+      expect(state.totalTokens).toBeGreaterThan(0);
+      expect(state.totalCost).not.toBeNull();
+    });
+
+    it("resets single calculation when leaving comparison mode with no model", () => {
+      const s = useBoundStore.getState();
+      s.setComparisonMode(true);
+      // No models selected
+      useBoundStore.getState().setComparisonMode(false);
+      const state = useBoundStore.getState();
+      expect(state.totalTokens).toBeNull();
+      expect(state.totalCost).toBeNull();
     });
   });
 
@@ -240,6 +298,22 @@ describe("ComparisonStore", () => {
       s.toggleModelSelection(tileModel);
       s.runComparison();
       expect(useBoundStore.getState().comparisonResults).toEqual([]);
+    });
+
+    it("resets expandedModelName when results are cleared", () => {
+      const s = useBoundStore.getState();
+      s.toggleModelSelection(tileModel);
+      s.addImage({ height: 1024, width: 1024, multiplier: 1 });
+      s.runComparison();
+      s.setExpandedModel(tileModel.name);
+      expect(useBoundStore.getState().expandedModelName).toBe(tileModel.name);
+
+      // Remove all images so runComparison clears results
+      useBoundStore.setState({ images: [] });
+      useBoundStore.getState().runComparison();
+      const state = useBoundStore.getState();
+      expect(state.comparisonResults).toEqual([]);
+      expect(state.expandedModelName).toBeNull();
     });
 
     it("recalculates when images change", () => {

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -2,9 +2,11 @@ import { create } from "zustand";
 import { modelStore } from "./ModelStore";
 import { calcStore } from "./CalcStore";
 import { presetStore } from "./PresetStore";
+import { comparisonStore } from "./ComparisonStore";
 
 export const useBoundStore = create((...a) => ({
   ...modelStore(...a),
   ...calcStore(...a),
   ...presetStore(...a),
+  ...comparisonStore(...a),
 }));


### PR DESCRIPTION
This pull request introduces a comprehensive "model comparison" mode to the calculator, allowing users to select multiple models and compare their token and cost estimates side by side. The UI has been updated to support toggling between single-model and comparison modes, with new components and logic for selecting multiple models, displaying comparison tables, and showing per-image breakdowns for each model.

The most important changes are:

**Model Comparison Feature:**
* Added a toggle button group in `Calculator.jsx` to switch between single-model and comparison modes, updating UI text and behavior accordingly.
* Implemented multi-select model selection in `ModelSelector.jsx` using checkboxes and the MUI `Autocomplete` component, with logic to add or remove models and trigger comparison calculations. [[1]](diffhunk://#diff-b98dc2970d0ce157f46082c26da35175cea03f42b376e30cd3a180f982e4d9b1R4-R102) [[2]](diffhunk://#diff-b98dc2970d0ce157f46082c26da35175cea03f42b376e30cd3a180f982e4d9b1L62-R145)
* Introduced `ComparisonTable`, `ComparisonRow`, and `ComparisonDetail` components to render a sortable table of comparison results, with expandable rows for per-image details. [[1]](diffhunk://#diff-3fe172f505ef7ee3092f68b34c08f41891dfec22096251eab2640884c3363b6fR1-R78) [[2]](diffhunk://#diff-76d31697236f87787bc811e0a043c7f2f4d27e7df1bdc03dd1de620fdcfb9c63R1-R55) [[3]](diffhunk://#diff-f15025a4e193219e5c120c430a358599fc9dd1eb3d9ccb59bd6cf8ac8d66ac88R1-R53)

**UI and Explanation Updates:**
* Updated `CalculationExplanation.jsx` to provide context-sensitive explanations for comparison mode, including instructions and model-specific tokenization details.
* In `CalculatorOutput.jsx`, improved empty state messaging and added a collapsible per-image breakdown for single-model mode, matching the new comparison UI. [[1]](diffhunk://#diff-25677943c5d70871ccc1e032a155f9a30d60f6068919bfd7b99887bf6bec8bceR1) [[2]](diffhunk://#diff-25677943c5d70871ccc1e032a155f9a30d60f6068919bfd7b99887bf6bec8bceL67-R141) [[3]](diffhunk://#diff-25677943c5d70871ccc1e032a155f9a30d60f6068919bfd7b99887bf6bec8bceL105-R175)

**Calculation Logic:**
* Modified `ImageEditor.jsx` to trigger the appropriate calculation function (`runCalculation` or `runComparison`) based on the selected mode.

These changes collectively provide a more powerful and user-friendly experience for comparing model costs and tokenization strategies.