### PR TITLE
feat: add copy results to clipboard

### DIFF
--- a/src/components/calculator/CalculatorOutput.jsx
+++ b/src/components/calculator/CalculatorOutput.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   Table,
   TableBody,
@@ -13,20 +13,50 @@ import {
   Chip,
   Collapse,
   IconButton,
+  Button,
 } from "@mui/material";
 import {
   BarChartOutlined,
   ExpandMore,
   ExpandLess,
+  ContentCopy,
+  Check,
 } from "@mui/icons-material";
 import { useBoundStore } from "../../stores";
 import ModelComment from "./comparison/ModelComment";
+import { formatResultsAsText } from "../../utils/formatResults";
 
 export default function CalculatorOutput() {
   const totalTokens = useBoundStore((s) => s.totalTokens);
   const totalCost = useBoundStore((s) => s.totalCost);
   const model = useBoundStore((s) => s.model);
+  const images = useBoundStore((s) => s.images);
   const imageResults = useBoundStore((s) => s.imageResults);
+
+  const [copyState, setCopyState] = useState("idle"); // "idle" | "copied" | "failed"
+
+  const handleCopy = useCallback(async () => {
+    const text = formatResultsAsText({
+      model,
+      images,
+      imageResults,
+      totalTokens,
+      totalCost,
+    });
+
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyState("copied");
+    } catch {
+      setCopyState("failed");
+    }
+  }, [model, images, imageResults, totalTokens, totalCost]);
+
+  useEffect(() => {
+    if (copyState === "idle") return;
+    const timer = setTimeout(() => setCopyState("idle"), 2000);
+    return () => clearTimeout(timer);
+  }, [copyState]);
 
   if (totalTokens === null) {
     return (
@@ -65,6 +95,20 @@ export default function CalculatorOutput() {
           />
         )}
         <ModelComment comment={model?.comment} />
+        <Button
+          size="small"
+          variant="outlined"
+          startIcon={copyState === "copied" ? <Check /> : <ContentCopy />}
+          color={copyState === "failed" ? "error" : copyState === "copied" ? "success" : "primary"}
+          onClick={handleCopy}
+          sx={{ ml: "auto" }}
+        >
+          {copyState === "copied"
+            ? "Copied!"
+            : copyState === "failed"
+              ? "Copy failed"
+              : "Copy results"}
+        </Button>
       </Stack>
       <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: "block" }}>
         Results update as you change inputs

--- a/src/components/calculator/CalculatorOutput.jsx
+++ b/src/components/calculator/CalculatorOutput.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import {
   Table,
   TableBody,
@@ -13,18 +13,16 @@ import {
   Chip,
   Collapse,
   IconButton,
-  Button,
 } from "@mui/material";
 import {
   BarChartOutlined,
   ExpandMore,
   ExpandLess,
-  ContentCopy,
-  Check,
 } from "@mui/icons-material";
 import { useBoundStore } from "../../stores";
 import ModelComment from "./comparison/ModelComment";
-import { formatResultsAsText } from "../../utils/formatResults";
+import CopyResultsButton from "./CopyResultsButton";
+import { formatResultsAsText, formatResultsAsTsv } from "../../utils/formatResults";
 
 export default function CalculatorOutput() {
   const totalTokens = useBoundStore((s) => s.totalTokens);
@@ -33,30 +31,12 @@ export default function CalculatorOutput() {
   const images = useBoundStore((s) => s.images);
   const imageResults = useBoundStore((s) => s.imageResults);
 
-  const [copyState, setCopyState] = useState("idle"); // "idle" | "copied" | "failed"
-
-  const handleCopy = useCallback(async () => {
-    const text = formatResultsAsText({
-      model,
-      images,
-      imageResults,
-      totalTokens,
-      totalCost,
-    });
-
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopyState("copied");
-    } catch {
-      setCopyState("failed");
-    }
-  }, [model, images, imageResults, totalTokens, totalCost]);
-
-  useEffect(() => {
-    if (copyState === "idle") return;
-    const timer = setTimeout(() => setCopyState("idle"), 2000);
-    return () => clearTimeout(timer);
-  }, [copyState]);
+  const copyFormats = {
+    text: () =>
+      formatResultsAsText({ model, images, imageResults, totalTokens, totalCost }),
+    table: () =>
+      formatResultsAsTsv({ model, images, imageResults, totalTokens, totalCost }),
+  };
 
   if (totalTokens === null) {
     return (
@@ -84,31 +64,20 @@ export default function CalculatorOutput() {
       sx={(theme) => ({ mt: 4, scrollMarginTop: `calc(${theme.spacing(10)})` })}
     >
       <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
-        <Typography variant="h6">Result</Typography>
-        {model?.name && <Chip size="small" label={model.name} />}
-        {model?.retirementDate && (
-          <Chip
-            size="small"
-            label={`Retires ${model.retirementDate}`}
-            color="warning"
-            variant="outlined"
-          />
-        )}
-        <ModelComment comment={model?.comment} />
-        <Button
-          size="small"
-          variant="outlined"
-          startIcon={copyState === "copied" ? <Check /> : <ContentCopy />}
-          color={copyState === "failed" ? "error" : copyState === "copied" ? "success" : "primary"}
-          onClick={handleCopy}
-          sx={{ ml: "auto" }}
-        >
-          {copyState === "copied"
-            ? "Copied!"
-            : copyState === "failed"
-              ? "Copy failed"
-              : "Copy results"}
-        </Button>
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ flex: 1, flexWrap: "wrap" }}>
+          <Typography variant="h6">Result</Typography>
+          {model?.name && <Chip size="small" label={model.name} />}
+          {model?.retirementDate && (
+            <Chip
+              size="small"
+              label={`Retires ${model.retirementDate}`}
+              color="warning"
+              variant="outlined"
+            />
+          )}
+          <ModelComment comment={model?.comment} />
+        </Stack>
+        <CopyResultsButton formats={copyFormats} />
       </Stack>
       <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: "block" }}>
         Results update as you change inputs

--- a/src/components/calculator/CopyResultsButton.jsx
+++ b/src/components/calculator/CopyResultsButton.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useId } from "react";
 import {
   Button,
   Menu,
@@ -24,6 +24,9 @@ import {
 export default function CopyResultsButton({ formats }) {
   const [anchorEl, setAnchorEl] = useState(null);
   const [copyState, setCopyState] = useState("idle");
+  const menuId = useId();
+  const buttonId = useId();
+  const open = Boolean(anchorEl);
 
   const handleOpen = (e) => setAnchorEl(e.currentTarget);
   const handleClose = () => setAnchorEl(null);
@@ -67,24 +70,33 @@ export default function CopyResultsButton({ formats }) {
         ? "Copy failed"
         : "Copy results";
 
+  const isIdle = copyState === "idle";
+
   return (
     <>
       <Button
+        id={buttonId}
         size="small"
         variant="outlined"
         startIcon={icon}
-        endIcon={copyState === "idle" ? <ArrowDropDown /> : undefined}
+        endIcon={isIdle ? <ArrowDropDown /> : undefined}
         color={color}
-        onClick={copyState === "idle" ? handleOpen : undefined}
+        onClick={isIdle ? handleOpen : undefined}
+        disabled={!isIdle}
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
       >
         {label}
       </Button>
       <Menu
+        id={menuId}
         anchorEl={anchorEl}
-        open={Boolean(anchorEl)}
+        open={open}
         onClose={handleClose}
         anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
         transformOrigin={{ vertical: "top", horizontal: "right" }}
+        MenuListProps={{ "aria-labelledby": buttonId }}
       >
         <MenuItem onClick={() => handleCopy(formats.text)}>
           <ListItemIcon>

--- a/src/components/calculator/CopyResultsButton.jsx
+++ b/src/components/calculator/CopyResultsButton.jsx
@@ -1,0 +1,104 @@
+import { useState, useEffect } from "react";
+import {
+  Button,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
+} from "@mui/material";
+import {
+  ContentCopy,
+  Check,
+  ArrowDropDown,
+  TextSnippetOutlined,
+  TableChartOutlined,
+  ErrorOutlined,
+} from "@mui/icons-material";
+
+/**
+ * A dropdown copy button that lets the user choose between plain-text
+ * and spreadsheet-friendly (TSV) clipboard formats.
+ *
+ * @param {{ formats: { text: () => string, table: () => string } }} props
+ */
+export default function CopyResultsButton({ formats }) {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [copyState, setCopyState] = useState("idle");
+
+  const handleOpen = (e) => setAnchorEl(e.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+
+  const handleCopy = async (getText) => {
+    handleClose();
+    try {
+      await navigator.clipboard.writeText(getText());
+      setCopyState("copied");
+    } catch {
+      setCopyState("failed");
+    }
+  };
+
+  useEffect(() => {
+    if (copyState === "idle") return;
+    const timer = setTimeout(() => setCopyState("idle"), 2000);
+    return () => clearTimeout(timer);
+  }, [copyState]);
+
+  const icon =
+    copyState === "copied" ? (
+      <Check />
+    ) : copyState === "failed" ? (
+      <ErrorOutlined />
+    ) : (
+      <ContentCopy />
+    );
+
+  const color =
+    copyState === "failed"
+      ? "error"
+      : copyState === "copied"
+        ? "success"
+        : "primary";
+
+  const label =
+    copyState === "copied"
+      ? "Copied!"
+      : copyState === "failed"
+        ? "Copy failed"
+        : "Copy results";
+
+  return (
+    <>
+      <Button
+        size="small"
+        variant="outlined"
+        startIcon={icon}
+        endIcon={copyState === "idle" ? <ArrowDropDown /> : undefined}
+        color={color}
+        onClick={copyState === "idle" ? handleOpen : undefined}
+      >
+        {label}
+      </Button>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+      >
+        <MenuItem onClick={() => handleCopy(formats.text)}>
+          <ListItemIcon>
+            <TextSnippetOutlined fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>As text</ListItemText>
+        </MenuItem>
+        <MenuItem onClick={() => handleCopy(formats.table)}>
+          <ListItemIcon>
+            <TableChartOutlined fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>As table (for spreadsheets)</ListItemText>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/src/components/calculator/comparison/ComparisonTable.jsx
+++ b/src/components/calculator/comparison/ComparisonTable.jsx
@@ -14,13 +14,21 @@ import {
 import { CompareArrowsOutlined } from "@mui/icons-material";
 import { useBoundStore } from "../../../stores";
 import ComparisonRow from "./ComparisonRow";
+import CopyResultsButton from "../CopyResultsButton";
+import { formatComparisonAsText, formatComparisonAsTsv } from "../../../utils/formatResults";
 
 export default function ComparisonTable() {
   const comparisonResults = useBoundStore((s) => s.comparisonResults);
+  const images = useBoundStore((s) => s.images);
   const expandedModelName = useBoundStore((s) => s.expandedModelName);
   const setExpandedModel = useBoundStore((s) => s.setExpandedModel);
   const sortOrder = useBoundStore((s) => s.comparisonSortOrder);
   const toggleSort = useBoundStore((s) => s.toggleComparisonSortOrder);
+
+  const copyFormats = {
+    text: () => formatComparisonAsText({ images, comparisonResults }),
+    table: () => formatComparisonAsTsv({ comparisonResults }),
+  };
 
   if (comparisonResults.length === 0) {
     return (
@@ -35,13 +43,14 @@ export default function ComparisonTable() {
 
   return (
     <Box id="results" sx={(theme) => ({ mt: 4, scrollMarginTop: `calc(${theme.spacing(10)})` })}>
-      <Stack spacing={1} sx={{ mb: 2 }}>
-        <Typography variant="h6">Comparison Results</Typography>
-        <Typography variant="body2" color="text.secondary">
-          Click the Estimated Cost header to toggle sort order. Click a row to
-          see per-image details.
-        </Typography>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
+        <Typography variant="h6" sx={{ flex: 1 }}>Comparison Results</Typography>
+        <CopyResultsButton formats={copyFormats} />
       </Stack>
+      <Typography variant="caption" color="text.secondary" sx={{ mb: 2, display: "block" }}>
+        Click the Estimated Cost header to toggle sort order. Click a row to
+        see per-image details.
+      </Typography>
       <TableContainer component={Paper} variant="outlined">
         <Table size="small" aria-label="model comparison results">
           <TableHead>

--- a/src/utils/__tests__/formatResults.test.js
+++ b/src/utils/__tests__/formatResults.test.js
@@ -270,6 +270,55 @@ describe("formatResultsAsText", () => {
     expect(text).toContain("Total tokens: 0");
     expect(text).toContain("Azure OpenAI Image Token Calculator");
   });
+
+  it("preserves original image numbering when middle entry is filtered out", () => {
+    const text = formatResultsAsText({
+      model: patchModel,
+      images: [
+        { width: 1024, height: 768, multiplier: 1 },
+        { width: 0, height: 0, multiplier: 1 },
+        { width: 1920, height: 1080, multiplier: 1 },
+      ],
+      imageResults: [
+        {
+          resizedWidth: 1024,
+          resizedHeight: 768,
+          tokenization: { type: "patch", totalPatches: 768, imageTokens: 768 },
+        },
+        { resizedWidth: 0, resizedHeight: 0, tokenization: null },
+        {
+          resizedWidth: 1920,
+          resizedHeight: 1080,
+          tokenization: { type: "patch", totalPatches: 2040, imageTokens: 2040 },
+        },
+      ],
+      totalTokens: 2808,
+      totalCost: "0.00702",
+    });
+
+    expect(text).toContain("Image 1:");
+    expect(text).not.toContain("Image 2:");
+    expect(text).toContain("Image 3:");
+  });
+
+  it("handles undefined images array gracefully", () => {
+    const text = formatResultsAsText({
+      model: patchModel,
+      images: undefined,
+      imageResults: [
+        {
+          resizedWidth: 512,
+          resizedHeight: 512,
+          tokenization: { type: "patch", totalPatches: 256, imageTokens: 256 },
+        },
+      ],
+      totalTokens: 256,
+      totalCost: "0.00064",
+    });
+
+    expect(text).toContain("Image 1:");
+    expect(text).toContain("?x?, Qty 1");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/utils/__tests__/formatResults.test.js
+++ b/src/utils/__tests__/formatResults.test.js
@@ -1,0 +1,268 @@
+import { describe, it, expect } from "vitest";
+import { formatResultsAsText } from "../formatResults";
+
+const patchModel = {
+  name: "GPT-5.4 (Global)",
+  tokenizationType: "patch",
+  patchSize: 32,
+  patchBudget: 2500,
+  tokenMultiplier: 1.0,
+  maxImageDimension: 2048,
+  costPerMillionTokens: 2.5,
+};
+
+const tileModel = {
+  name: "GPT-4o (2024-11-20 - Global)",
+  tokensPerTile: 170,
+  maxImageDimension: 2048,
+  imageMinSizeLength: 768,
+  tileSizeLength: 512,
+  baseTokens: 85,
+  costPerMillionTokens: 2.5,
+};
+
+describe("formatResultsAsText", () => {
+  it("formats patch-based results correctly", () => {
+    const text = formatResultsAsText({
+      model: patchModel,
+      images: [
+        { width: 1024, height: 768, multiplier: 2 },
+        { width: 1920, height: 1080, multiplier: 1 },
+      ],
+      imageResults: [
+        {
+          resizedWidth: 1024,
+          resizedHeight: 768,
+          tokenization: {
+            type: "patch",
+            patchesWide: 32,
+            patchesHigh: 24,
+            totalPatches: 1536,
+            tokenMultiplier: 1.0,
+            imageTokens: 1536,
+          },
+        },
+        {
+          resizedWidth: 1920,
+          resizedHeight: 1080,
+          tokenization: {
+            type: "patch",
+            patchesWide: 60,
+            patchesHigh: 34,
+            totalPatches: 2040,
+            tokenMultiplier: 1.0,
+            imageTokens: 2040,
+          },
+        },
+      ],
+      totalTokens: 3576,
+      totalCost: "0.00894",
+    });
+
+    expect(text).toContain("Azure OpenAI Image Token Calculator");
+    expect(text).toContain("GPT-5.4 (Global)");
+    expect(text).toContain("[Patch-based]");
+    expect(text).toContain("Image 1:");
+    expect(text).toContain("1024x768, Qty 2");
+    expect(text).toContain("patches");
+    expect(text).toContain("Image 2:");
+    expect(text).toContain("1920x1080, Qty 1");
+    expect(text).toContain("Total tokens:");
+    expect(text).toContain("Estimated cost:");
+    expect(text).toContain("$2.5/1M tokens");
+  });
+
+  it("formats tile-based results correctly", () => {
+    const text = formatResultsAsText({
+      model: tileModel,
+      images: [{ width: 1024, height: 768, multiplier: 1 }],
+      imageResults: [
+        {
+          resizedWidth: 1024,
+          resizedHeight: 768,
+          tokenization: {
+            type: "tile",
+            tilesHigh: 2,
+            tilesWide: 2,
+            totalTiles: 4,
+            tokensPerTile: 170,
+            baseTokens: 85,
+            imageTokens: 765,
+          },
+        },
+      ],
+      totalTokens: 765,
+      totalCost: "0.00191",
+    });
+
+    expect(text).toContain("[Tile-based]");
+    expect(text).toContain("GPT-4o (2024-11-20 - Global)");
+    expect(text).toContain("tiles");
+    expect(text).not.toContain("patches");
+    expect(text).toContain("765 tokens");
+  });
+
+  it("includes retirement date when present", () => {
+    const model = { ...tileModel, retirementDate: "Oct 2026" };
+    const text = formatResultsAsText({
+      model,
+      images: [{ width: 100, height: 100, multiplier: 1 }],
+      imageResults: [
+        {
+          resizedWidth: 100,
+          resizedHeight: 100,
+          tokenization: {
+            type: "tile",
+            tilesHigh: 1,
+            tilesWide: 1,
+            totalTiles: 1,
+            tokensPerTile: 170,
+            baseTokens: 85,
+            imageTokens: 255,
+          },
+        },
+      ],
+      totalTokens: 255,
+      totalCost: "0.00064",
+    });
+
+    expect(text).toContain("Note: This model retires Oct 2026");
+  });
+
+  it("includes model comment when present", () => {
+    const model = {
+      ...tileModel,
+      comment: "This calculator only provides input tokens.",
+    };
+    const text = formatResultsAsText({
+      model,
+      images: [{ width: 100, height: 100, multiplier: 1 }],
+      imageResults: [
+        {
+          resizedWidth: 100,
+          resizedHeight: 100,
+          tokenization: {
+            type: "tile",
+            tilesHigh: 1,
+            tilesWide: 1,
+            totalTiles: 1,
+            tokensPerTile: 170,
+            baseTokens: 85,
+            imageTokens: 255,
+          },
+        },
+      ],
+      totalTokens: 255,
+      totalCost: "0.00064",
+    });
+
+    expect(text).toContain(
+      "Note: This calculator only provides input tokens.",
+    );
+  });
+
+  it("includes both retirement date and comment", () => {
+    const model = {
+      ...tileModel,
+      retirementDate: "Jul 2026",
+      comment: "Only input tokens are shown.",
+    };
+    const text = formatResultsAsText({
+      model,
+      images: [{ width: 100, height: 100, multiplier: 1 }],
+      imageResults: [
+        {
+          resizedWidth: 100,
+          resizedHeight: 100,
+          tokenization: {
+            type: "tile",
+            tilesHigh: 1,
+            tilesWide: 1,
+            totalTiles: 1,
+            tokensPerTile: 170,
+            baseTokens: 85,
+            imageTokens: 255,
+          },
+        },
+      ],
+      totalTokens: 255,
+      totalCost: "0.00064",
+    });
+
+    expect(text).toContain("retires Jul 2026");
+    expect(text).toContain("Only input tokens are shown.");
+  });
+
+  it("skips image entries with missing tokenization data", () => {
+    const text = formatResultsAsText({
+      model: patchModel,
+      images: [
+        { width: 1024, height: 768, multiplier: 1 },
+        { width: 0, height: 0, multiplier: 1 },
+      ],
+      imageResults: [
+        {
+          resizedWidth: 1024,
+          resizedHeight: 768,
+          tokenization: {
+            type: "patch",
+            patchesWide: 32,
+            patchesHigh: 24,
+            totalPatches: 768,
+            tokenMultiplier: 1.0,
+            imageTokens: 768,
+          },
+        },
+        {
+          resizedWidth: 0,
+          resizedHeight: 0,
+          tokenization: null,
+        },
+      ],
+      totalTokens: 768,
+      totalCost: "0.00192",
+    });
+
+    expect(text).toContain("Image 1:");
+    expect(text).not.toContain("Image 2:");
+  });
+
+  it("handles missing image metadata gracefully", () => {
+    const text = formatResultsAsText({
+      model: patchModel,
+      images: [undefined],
+      imageResults: [
+        {
+          resizedWidth: 512,
+          resizedHeight: 512,
+          tokenization: {
+            type: "patch",
+            patchesWide: 16,
+            patchesHigh: 16,
+            totalPatches: 256,
+            tokenMultiplier: 1.0,
+            imageTokens: 256,
+          },
+        },
+      ],
+      totalTokens: 256,
+      totalCost: "0.00064",
+    });
+
+    expect(text).toContain("Image 1:");
+    expect(text).toContain("?x?, Qty 1");
+  });
+
+  it("handles empty results", () => {
+    const text = formatResultsAsText({
+      model: patchModel,
+      images: [],
+      imageResults: [],
+      totalTokens: 0,
+      totalCost: "0",
+    });
+
+    expect(text).toContain("Total tokens: 0");
+    expect(text).toContain("Azure OpenAI Image Token Calculator");
+  });
+});

--- a/src/utils/__tests__/formatResults.test.js
+++ b/src/utils/__tests__/formatResults.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { formatResultsAsText } from "../formatResults";
+import {
+  formatResultsAsText,
+  formatResultsAsTsv,
+  formatComparisonAsText,
+  formatComparisonAsTsv,
+} from "../formatResults";
 
 const patchModel = {
   name: "GPT-5.4 (Global)",
@@ -264,5 +269,204 @@ describe("formatResultsAsText", () => {
 
     expect(text).toContain("Total tokens: 0");
     expect(text).toContain("Azure OpenAI Image Token Calculator");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatResultsAsTsv
+// ---------------------------------------------------------------------------
+
+describe("formatResultsAsTsv", () => {
+  it("produces tab-separated output for patch-based models", () => {
+    const tsv = formatResultsAsTsv({
+      model: patchModel,
+      images: [
+        { width: 1024, height: 768, multiplier: 2 },
+        { width: 1920, height: 1080, multiplier: 1 },
+      ],
+      imageResults: [
+        {
+          resizedWidth: 1024,
+          resizedHeight: 768,
+          tokenization: {
+            type: "patch",
+            totalPatches: 1536,
+            imageTokens: 1536,
+          },
+        },
+        {
+          resizedWidth: 1920,
+          resizedHeight: 1080,
+          tokenization: {
+            type: "patch",
+            totalPatches: 2040,
+            imageTokens: 2040,
+          },
+        },
+      ],
+      totalTokens: 3576,
+      totalCost: "0.00894",
+    });
+
+    const lines = tsv.split("\n");
+    // Header row uses tabs
+    expect(lines[0]).toBe("Image\tOriginal Size\tQty\tResized Size\tPatches\tTokens");
+    // Data rows are tab-separated
+    expect(lines[1]).toContain("1024x768");
+    expect(lines[1]).toContain("2");
+    expect(lines[1].split("\t").length).toBe(6);
+    // Totals
+    expect(tsv).toContain("Total Tokens\t3576");
+    expect(tsv).toContain("Model\tGPT-5.4 (Global)");
+  });
+
+  it("produces tab-separated output for tile-based models", () => {
+    const tsv = formatResultsAsTsv({
+      model: tileModel,
+      images: [{ width: 1024, height: 768, multiplier: 1 }],
+      imageResults: [
+        {
+          resizedWidth: 1024,
+          resizedHeight: 768,
+          tokenization: {
+            type: "tile",
+            totalTiles: 4,
+            imageTokens: 765,
+          },
+        },
+      ],
+      totalTokens: 765,
+      totalCost: "0.00191",
+    });
+
+    expect(tsv).toContain("Tiles");
+    expect(tsv).not.toContain("Patches");
+    expect(tsv).toContain("Total Tokens\t765");
+  });
+
+  it("skips entries with missing tokenization", () => {
+    const tsv = formatResultsAsTsv({
+      model: patchModel,
+      images: [
+        { width: 512, height: 512, multiplier: 1 },
+        { width: 0, height: 0, multiplier: 1 },
+      ],
+      imageResults: [
+        {
+          resizedWidth: 512,
+          resizedHeight: 512,
+          tokenization: { type: "patch", totalPatches: 256, imageTokens: 256 },
+        },
+        { resizedWidth: 0, resizedHeight: 0, tokenization: null },
+      ],
+      totalTokens: 256,
+      totalCost: "0.00064",
+    });
+
+    const dataLines = tsv.split("\n").filter((l) => l.startsWith("1") || l.startsWith("2"));
+    expect(dataLines).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatComparisonAsText
+// ---------------------------------------------------------------------------
+
+describe("formatComparisonAsText", () => {
+  it("formats a multi-model comparison", () => {
+    const text = formatComparisonAsText({
+      images: [{ width: 1024, height: 768, multiplier: 1 }],
+      comparisonResults: [
+        {
+          model: patchModel,
+          totalTokens: 768,
+          totalCost: "0.00192",
+          imageResults: [],
+        },
+        {
+          model: tileModel,
+          totalTokens: 765,
+          totalCost: "0.00191",
+          imageResults: [],
+        },
+      ],
+    });
+
+    expect(text).toContain("Model Comparison");
+    expect(text).toContain("GPT-5.4 (Global)");
+    expect(text).toContain("GPT-4o (2024-11-20 - Global)");
+    expect(text).toContain("Images: 1024x768");
+  });
+
+  it("includes retirement and comment notes", () => {
+    const retiringModel = {
+      ...tileModel,
+      retirementDate: "Oct 2026",
+      comment: "Input tokens only.",
+    };
+
+    const text = formatComparisonAsText({
+      images: [{ width: 100, height: 100, multiplier: 1 }],
+      comparisonResults: [
+        {
+          model: retiringModel,
+          totalTokens: 255,
+          totalCost: "0.00064",
+          imageResults: [],
+        },
+      ],
+    });
+
+    expect(text).toContain("Retires Oct 2026");
+    expect(text).toContain("Note [GPT-4o (2024-11-20 - Global)]: Input tokens only.");
+  });
+
+  it("handles empty comparison results", () => {
+    const text = formatComparisonAsText({
+      images: [],
+      comparisonResults: [],
+    });
+
+    expect(text).toContain("No comparison results.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatComparisonAsTsv
+// ---------------------------------------------------------------------------
+
+describe("formatComparisonAsTsv", () => {
+  it("produces tab-separated comparison output", () => {
+    const tsv = formatComparisonAsTsv({
+      comparisonResults: [
+        {
+          model: patchModel,
+          totalTokens: 768,
+          totalCost: "0.00192",
+          imageResults: [],
+        },
+        {
+          model: { ...tileModel, retirementDate: "Oct 2026" },
+          totalTokens: 765,
+          totalCost: "0.00191",
+          imageResults: [],
+        },
+      ],
+    });
+
+    const lines = tsv.split("\n");
+    expect(lines[0]).toBe(
+      "Model\tType\tTotal Tokens\tEstimated Cost\tRate\tRetirement",
+    );
+    expect(lines[1]).toContain("GPT-5.4 (Global)");
+    expect(lines[1]).toContain("Patch");
+    expect(lines[1].split("\t").length).toBe(6);
+    expect(lines[2]).toContain("Oct 2026");
+  });
+
+  it("handles empty comparison results", () => {
+    const tsv = formatComparisonAsTsv({ comparisonResults: [] });
+    const lines = tsv.split("\n");
+    expect(lines).toHaveLength(1); // header only
   });
 });

--- a/src/utils/formatResults.js
+++ b/src/utils/formatResults.js
@@ -38,10 +38,11 @@ export function formatResultsAsText({
 
   lines.push(""); // blank separator
 
-  // Per-image lines
-  const paired = imageResults.map((result, i) => ({
+  // Per-image lines - carry original index through filtering
+  const paired = (imageResults ?? []).map((result, i) => ({
     result,
-    image: images[i],
+    image: (images ?? [])[i],
+    originalIndex: i,
   }));
 
   const validPairs = paired.filter(
@@ -52,7 +53,7 @@ export function formatResultsAsText({
       result.tokenization,
   );
 
-  validPairs.forEach(({ result, image }, i) => {
+  validPairs.forEach(({ result, image, originalIndex }) => {
     const origW = image?.width ?? "?";
     const origH = image?.height ?? "?";
     const qty = image?.multiplier ?? 1;
@@ -69,7 +70,7 @@ export function formatResultsAsText({
     }
 
     lines.push(
-      `Image ${i + 1}: ${origW}x${origH}, Qty ${qty} - Resized to ${resized} - ${detail} - ${tokens} tokens`,
+      `Image ${originalIndex + 1}: ${origW}x${origH}, Qty ${qty} - Resized to ${resized} - ${detail} - ${tokens} tokens`,
     );
   });
 
@@ -169,7 +170,7 @@ export function formatComparisonAsText({ images, comparisonResults }) {
   if (commented.length > 0) {
     lines.push("");
     for (const r of commented) {
-      lines.push(`Note [${r.model.name}]: ${r.model.comment}`);
+      lines.push(`Note [${r.model?.name ?? "Unknown"}]: ${r.model.comment}`);
     }
   }
 
@@ -200,9 +201,10 @@ export function formatResultsAsTsv({
     ),
   );
 
-  const paired = imageResults.map((result, i) => ({
+  const paired = (imageResults ?? []).map((result, i) => ({
     result,
-    image: images[i],
+    image: (images ?? [])[i],
+    originalIndex: i,
   }));
 
   const validPairs = paired.filter(
@@ -213,7 +215,7 @@ export function formatResultsAsTsv({
       result.tokenization,
   );
 
-  validPairs.forEach(({ result, image }, i) => {
+  validPairs.forEach(({ result, image, originalIndex }) => {
     const origSize = `${image?.width ?? "?"}x${image?.height ?? "?"}`;
     const qty = image?.multiplier ?? 1;
     const resized = `${result.resizedWidth}x${result.resizedHeight}`;
@@ -222,7 +224,7 @@ export function formatResultsAsTsv({
       : result.tokenization.totalTiles;
     const tokens = result.tokenization.imageTokens;
 
-    rows.push([i + 1, origSize, qty, resized, units, tokens].join("\t"));
+    rows.push([originalIndex + 1, origSize, qty, resized, units, tokens].join("\t"));
   });
 
   rows.push(""); // blank separator row

--- a/src/utils/formatResults.js
+++ b/src/utils/formatResults.js
@@ -1,0 +1,87 @@
+const numberFormat = new Intl.NumberFormat();
+
+const currencyFormat = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 5,
+});
+
+/**
+ * Build a plain-text summary of the calculation results suitable for
+ * pasting into documents, messages, or cost analyses.
+ *
+ * @param {{ model: object, images: object[], imageResults: object[], totalTokens: number, totalCost: string|number }} params
+ * @returns {string}
+ */
+export function formatResultsAsText({
+  model,
+  images,
+  imageResults,
+  totalTokens,
+  totalCost,
+}) {
+  const isPatch = model?.tokenizationType === "patch";
+  const lines = ["Azure OpenAI Image Token Calculator"];
+
+  // Model header
+  const tokenLabel = isPatch ? "Patch-based" : "Tile-based";
+  lines.push(`Model: ${model?.name ?? "Unknown"} [${tokenLabel}]`);
+
+  if (model?.retirementDate) {
+    lines.push(`Note: This model retires ${model.retirementDate}`);
+  }
+
+  if (model?.comment) {
+    lines.push(`Note: ${model.comment}`);
+  }
+
+  lines.push(""); // blank separator
+
+  // Per-image lines
+  const paired = imageResults.map((result, i) => ({
+    result,
+    image: images[i],
+  }));
+
+  const validPairs = paired.filter(
+    ({ result }) =>
+      result &&
+      typeof result.resizedHeight === "number" &&
+      typeof result.resizedWidth === "number" &&
+      result.tokenization,
+  );
+
+  validPairs.forEach(({ result, image }, i) => {
+    const origW = image?.width ?? "?";
+    const origH = image?.height ?? "?";
+    const qty = image?.multiplier ?? 1;
+    const resized = `${result.resizedWidth}x${result.resizedHeight}`;
+    const tokens = numberFormat.format(result.tokenization.imageTokens);
+
+    let detail;
+    if (isPatch) {
+      const patches = numberFormat.format(result.tokenization.totalPatches);
+      detail = `${patches} patches`;
+    } else {
+      const tiles = numberFormat.format(result.tokenization.totalTiles);
+      detail = `${tiles} tiles`;
+    }
+
+    lines.push(
+      `Image ${i + 1}: ${origW}x${origH}, Qty ${qty} - Resized to ${resized} - ${detail} - ${tokens} tokens`,
+    );
+  });
+
+  lines.push(""); // blank separator
+
+  // Totals
+  const formattedTokens = numberFormat.format(totalTokens);
+  const formattedCost = currencyFormat.format(Number(totalCost));
+  const costRate = `$${model?.costPerMillionTokens ?? "?"}/1M tokens`;
+
+  lines.push(`Total tokens: ${formattedTokens}`);
+  lines.push(`Estimated cost: ${formattedCost} (${costRate})`);
+
+  return lines.join("\n");
+}

--- a/src/utils/formatResults.js
+++ b/src/utils/formatResults.js
@@ -85,3 +85,189 @@ export function formatResultsAsText({
 
   return lines.join("\n");
 }
+
+/**
+ * Build a plain-text comparison table of multiple model results suitable
+ * for pasting into documents, messages, or cost analyses.
+ *
+ * @param {{ images: object[], comparisonResults: { model: object, totalTokens: number, totalCost: string|number, imageResults: object[] }[] }} params
+ * @returns {string}
+ */
+export function formatComparisonAsText({ images, comparisonResults }) {
+  const lines = [
+    "Azure OpenAI Image Token Calculator - Model Comparison",
+    "",
+  ];
+
+  // Image summary
+  const validImages = (images ?? []).filter(
+    (img) => img && img.width > 0 && img.height > 0,
+  );
+  if (validImages.length > 0) {
+    const descriptions = validImages.map((img) => {
+      const qty = img.multiplier ?? 1;
+      return `${img.width}x${img.height}${qty > 1 ? ` (Qty ${qty})` : ""}`;
+    });
+    lines.push(`Images: ${descriptions.join(", ")}`);
+    lines.push("");
+  }
+
+  if (!comparisonResults || comparisonResults.length === 0) {
+    lines.push("No comparison results.");
+    return lines.join("\n");
+  }
+
+  // Build table rows
+  const rows = comparisonResults.map((r) => {
+    const tokenType =
+      r.model?.tokenizationType === "patch" ? "Patch" : "Tile";
+    const tokens = numberFormat.format(r.totalTokens);
+    const cost = currencyFormat.format(Number(r.totalCost));
+    const rate = `$${r.model?.costPerMillionTokens ?? "?"}/1M tokens`;
+    const name = r.model?.name ?? "Unknown";
+    const retirement = r.model?.retirementDate
+      ? `Retires ${r.model.retirementDate}`
+      : "";
+    return { name, tokenType, tokens, cost, rate, retirement };
+  });
+
+  // Calculate column widths for alignment
+  const headers = {
+    name: "Model",
+    tokenType: "Type",
+    tokens: "Total Tokens",
+    cost: "Estimated Cost",
+    rate: "Rate",
+  };
+
+  const cols = ["name", "tokenType", "tokens", "cost", "rate"];
+  const widths = {};
+  for (const col of cols) {
+    widths[col] = Math.max(
+      headers[col].length,
+      ...rows.map((r) => r[col].length),
+    );
+  }
+
+  const pad = (str, width) => str.padEnd(width);
+  const headerLine = cols.map((c) => pad(headers[c], widths[c])).join(" | ");
+  const separator = cols.map((c) => "-".repeat(widths[c])).join("-|-");
+
+  lines.push(headerLine);
+  lines.push(separator);
+
+  for (const row of rows) {
+    let line = cols.map((c) => pad(row[c], widths[c])).join(" | ");
+    if (row.retirement) {
+      line += ` (${row.retirement})`;
+    }
+    lines.push(line);
+  }
+
+  // Notes for models with comments
+  const commented = comparisonResults.filter((r) => r.model?.comment);
+  if (commented.length > 0) {
+    lines.push("");
+    for (const r of commented) {
+      lines.push(`Note [${r.model.name}]: ${r.model.comment}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Build a TSV (tab-separated values) version of single-model results
+ * that pastes cleanly into spreadsheet applications.
+ *
+ * @param {{ model: object, images: object[], imageResults: object[], totalTokens: number, totalCost: string|number }} params
+ * @returns {string}
+ */
+export function formatResultsAsTsv({
+  model,
+  images,
+  imageResults,
+  totalTokens,
+  totalCost,
+}) {
+  const isPatch = model?.tokenizationType === "patch";
+  const unitLabel = isPatch ? "Patches" : "Tiles";
+  const rows = [];
+
+  rows.push(
+    ["Image", "Original Size", "Qty", "Resized Size", unitLabel, "Tokens"].join(
+      "\t",
+    ),
+  );
+
+  const paired = imageResults.map((result, i) => ({
+    result,
+    image: images[i],
+  }));
+
+  const validPairs = paired.filter(
+    ({ result }) =>
+      result &&
+      typeof result.resizedHeight === "number" &&
+      typeof result.resizedWidth === "number" &&
+      result.tokenization,
+  );
+
+  validPairs.forEach(({ result, image }, i) => {
+    const origSize = `${image?.width ?? "?"}x${image?.height ?? "?"}`;
+    const qty = image?.multiplier ?? 1;
+    const resized = `${result.resizedWidth}x${result.resizedHeight}`;
+    const units = isPatch
+      ? result.tokenization.totalPatches
+      : result.tokenization.totalTiles;
+    const tokens = result.tokenization.imageTokens;
+
+    rows.push([i + 1, origSize, qty, resized, units, tokens].join("\t"));
+  });
+
+  rows.push(""); // blank separator row
+  rows.push(["Total Tokens", totalTokens].join("\t"));
+
+  const formattedCost = currencyFormat.format(Number(totalCost));
+  const rate = `$${model?.costPerMillionTokens ?? "?"}/1M tokens`;
+  rows.push(["Estimated Cost", `${formattedCost} (${rate})`].join("\t"));
+
+  if (model?.name) {
+    rows.push(["Model", model.name].join("\t"));
+  }
+
+  return rows.join("\n");
+}
+
+/**
+ * Build a TSV (tab-separated values) version of comparison results
+ * that pastes cleanly into spreadsheet applications.
+ *
+ * @param {{ comparisonResults: { model: object, totalTokens: number, totalCost: string|number, imageResults: object[] }[] }} params
+ * @returns {string}
+ */
+export function formatComparisonAsTsv({ comparisonResults }) {
+  const rows = [];
+
+  rows.push(
+    ["Model", "Type", "Total Tokens", "Estimated Cost", "Rate", "Retirement"].join("\t"),
+  );
+
+  if (!comparisonResults || comparisonResults.length === 0) {
+    return rows.join("\n");
+  }
+
+  for (const r of comparisonResults) {
+    const name = r.model?.name ?? "Unknown";
+    const tokenType =
+      r.model?.tokenizationType === "patch" ? "Patch" : "Tile";
+    const tokens = r.totalTokens;
+    const cost = currencyFormat.format(Number(r.totalCost));
+    const rate = `$${r.model?.costPerMillionTokens ?? "?"}/1M tokens`;
+    const retirement = r.model?.retirementDate ?? "";
+
+    rows.push([name, tokenType, tokens, cost, rate, retirement].join("\t"));
+  }
+
+  return rows.join("\n");
+}


### PR DESCRIPTION
This pull request adds a new feature that allows users to easily copy calculation and comparison results in both plain-text and spreadsheet-friendly (TSV) formats. A reusable `CopyResultsButton` component is introduced and integrated into both the single-model and comparison results views. Supporting utility functions for formatting results as text or TSV are also implemented.

**New copy-to-clipboard functionality:**

* Added a `CopyResultsButton` component that provides a dropdown button for copying results in either plain-text or TSV format, with user feedback for success or failure (`src/components/calculator/CopyResultsButton.jsx`).
* Integrated `CopyResultsButton` into the main calculator output and model comparison table, allowing users to copy results directly from both views (`src/components/calculator/CalculatorOutput.jsx`, [[1]](diffhunk://#diff-25677943c5d70871ccc1e032a155f9a30d60f6068919bfd7b99887bf6bec8bceR24-R40) [[2]](diffhunk://#diff-25677943c5d70871ccc1e032a155f9a30d60f6068919bfd7b99887bf6bec8bceR67) [[3]](diffhunk://#diff-25677943c5d70871ccc1e032a155f9a30d60f6068919bfd7b99887bf6bec8bceR80-R81); `src/components/calculator/comparison/ComparisonTable.jsx`, [[4]](diffhunk://#diff-3fe172f505ef7ee3092f68b34c08f41891dfec22096251eab2640884c3363b6fR17-R32) [[5]](diffhunk://#diff-3fe172f505ef7ee3092f68b34c08f41891dfec22096251eab2640884c3363b6fL38-L44)

**Result formatting utilities:**

* Added utility functions to format results and comparisons as plain text or TSV for clipboard copying (`src/utils/formatResults.js`). These functions handle detailed formatting, including per-image and per-model summaries, cost calculations, and notes.