### PR TITLE
feat: add cost projection for single and comparison modes

### DIFF
--- a/src/components/calculator/CalculatorOutput.jsx
+++ b/src/components/calculator/CalculatorOutput.jsx
@@ -22,6 +22,7 @@ import {
 import { useBoundStore } from "../../stores";
 import ModelComment from "./comparison/ModelComment";
 import CopyResultsButton from "./CopyResultsButton";
+import CostProjection from "./CostProjection";
 import { formatResultsAsText, formatResultsAsTsv } from "../../utils/formatResults";
 
 export default function CalculatorOutput() {
@@ -30,12 +31,13 @@ export default function CalculatorOutput() {
   const model = useBoundStore((s) => s.model);
   const images = useBoundStore((s) => s.images);
   const imageResults = useBoundStore((s) => s.imageResults);
+  const requestsPerDay = useBoundStore((s) => s.requestsPerDay);
 
   const copyFormats = {
     text: () =>
-      formatResultsAsText({ model, images, imageResults, totalTokens, totalCost }),
+      formatResultsAsText({ model, images, imageResults, totalTokens, totalCost, requestsPerDay }),
     table: () =>
-      formatResultsAsTsv({ model, images, imageResults, totalTokens, totalCost }),
+      formatResultsAsTsv({ model, images, imageResults, totalTokens, totalCost, requestsPerDay }),
   };
 
   if (totalTokens === null) {
@@ -100,6 +102,7 @@ export default function CalculatorOutput() {
       )}
 
       <ImageBreakdownList imageResults={imageResults} isPatch={isPatch} />
+      <CostProjection />
     </Box>
   );
 }

--- a/src/components/calculator/CostProjection.jsx
+++ b/src/components/calculator/CostProjection.jsx
@@ -1,0 +1,155 @@
+import {
+  Box,
+  TextField,
+  Typography,
+  Alert,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+} from "@mui/material";
+import { useBoundStore } from "../../stores";
+
+const currencyFormat = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 5,
+});
+
+export default function CostProjection() {
+  const totalCost = useBoundStore((s) => s.totalCost);
+  const model = useBoundStore((s) => s.model);
+  const requestsPerDay = useBoundStore((s) => s.requestsPerDay);
+  const setRequestsPerDay = useBoundStore((s) => s.setRequestsPerDay);
+  const comparisonMode = useBoundStore((s) => s.comparisonMode);
+  const comparisonResults = useBoundStore((s) => s.comparisonResults);
+
+  return (
+    <Box sx={{ mt: 3 }}>
+      <Typography variant="subtitle1" fontWeight={600} gutterBottom>
+        Cost Projection
+      </Typography>
+      <Typography variant="caption" color="text.secondary" sx={{ mb: 2, display: "block" }}>
+        Each request uses the full image set configured above.
+      </Typography>
+
+      <TextField
+        label="Requests per day"
+        type="number"
+        size="small"
+        value={requestsPerDay === 0 ? "" : requestsPerDay}
+        onChange={(e) => setRequestsPerDay(e.target.value)}
+        slotProps={{ htmlInput: { min: 0, step: 1 } }}
+        sx={{ width: 180, mb: 2 }}
+      />
+
+      {comparisonMode ? (
+        <ComparisonProjection
+          comparisonResults={comparisonResults}
+          requestsPerDay={requestsPerDay}
+        />
+      ) : (
+        <SingleProjection
+          totalCost={totalCost}
+          model={model}
+          requestsPerDay={requestsPerDay}
+        />
+      )}
+    </Box>
+  );
+}
+
+function SingleProjection({ totalCost, model, requestsPerDay }) {
+  const unitCost = Number.parseFloat(totalCost ?? "0");
+  const hasValidCost = Number.isFinite(unitCost) && unitCost > 0;
+
+  if (requestsPerDay <= 0 || !hasValidCost) return null;
+
+  const dailyCost = unitCost * requestsPerDay;
+  const monthlyCost = dailyCost * 30;
+
+  return (
+    <>
+      <TableContainer component={Paper} variant="outlined" sx={{ mb: 2 }}>
+        <Table size="small" aria-label="cost projection">
+          <TableHead>
+            <TableRow>
+              <TableCell>Cost per request</TableCell>
+              <TableCell align="right">Daily</TableCell>
+              <TableCell align="right">Monthly (30 days)</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            <TableRow>
+              <TableCell>{currencyFormat.format(unitCost)}</TableCell>
+              <TableCell align="right">{currencyFormat.format(dailyCost)}</TableCell>
+              <TableCell align="right">{currencyFormat.format(monthlyCost)}</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
+      {model?.comment && (
+        <Alert severity="info" variant="outlined">
+          This projection only covers the calculated token costs and may not
+          reflect full API costs. {model.comment}
+        </Alert>
+      )}
+    </>
+  );
+}
+
+function ComparisonProjection({ comparisonResults, requestsPerDay }) {
+  if (requestsPerDay <= 0 || !comparisonResults?.length) return null;
+
+  const hasComments = comparisonResults.some((r) => r.model?.comment);
+
+  return (
+    <>
+      <TableContainer component={Paper} variant="outlined" sx={{ mb: 2 }}>
+        <Table size="small" aria-label="cost projection comparison">
+          <TableHead>
+            <TableRow>
+              <TableCell>Model</TableCell>
+              <TableCell align="right">Cost per request</TableCell>
+              <TableCell align="right">Daily</TableCell>
+              <TableCell align="right">Monthly (30 days)</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {comparisonResults.map((r) => {
+              const unitCost = Number.parseFloat(r.totalCost ?? "0");
+              const valid = Number.isFinite(unitCost);
+              const daily = valid ? unitCost * requestsPerDay : 0;
+              const monthly = daily * 30;
+
+              return (
+                <TableRow key={r.model?.name}>
+                  <TableCell>{r.model?.name ?? "Unknown"}</TableCell>
+                  <TableCell align="right">
+                    {valid ? currencyFormat.format(unitCost) : "-"}
+                  </TableCell>
+                  <TableCell align="right">
+                    {valid ? currencyFormat.format(daily) : "-"}
+                  </TableCell>
+                  <TableCell align="right">
+                    {valid ? currencyFormat.format(monthly) : "-"}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      {hasComments && (
+        <Alert severity="info" variant="outlined">
+          Some models in this comparison only cover calculated token costs and
+          may not reflect full API costs.
+        </Alert>
+      )}
+    </>
+  );
+}

--- a/src/components/calculator/CostProjection.jsx
+++ b/src/components/calculator/CostProjection.jsx
@@ -43,7 +43,14 @@ export default function CostProjection() {
         size="small"
         value={requestsPerDay === 0 ? "" : requestsPerDay}
         onChange={(e) => setRequestsPerDay(e.target.value)}
-        slotProps={{ htmlInput: { min: 0, step: 1 } }}
+        slotProps={{
+          input: {
+            inputProps: {
+              min: 0,
+              step: 1,
+            },
+          },
+        }}
         sx={{ width: 180, mb: 2 }}
       />
 
@@ -120,14 +127,14 @@ function ComparisonProjection({ comparisonResults, requestsPerDay }) {
             </TableRow>
           </TableHead>
           <TableBody>
-            {comparisonResults.map((r) => {
+            {comparisonResults.map((r, index) => {
               const unitCost = Number.parseFloat(r.totalCost ?? "0");
               const valid = Number.isFinite(unitCost);
               const daily = valid ? unitCost * requestsPerDay : 0;
               const monthly = daily * 30;
 
               return (
-                <TableRow key={r.model?.name}>
+                <TableRow key={`${r.model?.name ?? "unknown"}-${index}`}>
                   <TableCell>{r.model?.name ?? "Unknown"}</TableCell>
                   <TableCell align="right">
                     {valid ? currencyFormat.format(unitCost) : "-"}

--- a/src/components/calculator/comparison/ComparisonTable.jsx
+++ b/src/components/calculator/comparison/ComparisonTable.jsx
@@ -15,19 +15,21 @@ import { CompareArrowsOutlined } from "@mui/icons-material";
 import { useBoundStore } from "../../../stores";
 import ComparisonRow from "./ComparisonRow";
 import CopyResultsButton from "../CopyResultsButton";
+import CostProjection from "../CostProjection";
 import { formatComparisonAsText, formatComparisonAsTsv } from "../../../utils/formatResults";
 
 export default function ComparisonTable() {
   const comparisonResults = useBoundStore((s) => s.comparisonResults);
   const images = useBoundStore((s) => s.images);
+  const requestsPerDay = useBoundStore((s) => s.requestsPerDay);
   const expandedModelName = useBoundStore((s) => s.expandedModelName);
   const setExpandedModel = useBoundStore((s) => s.setExpandedModel);
   const sortOrder = useBoundStore((s) => s.comparisonSortOrder);
   const toggleSort = useBoundStore((s) => s.toggleComparisonSortOrder);
 
   const copyFormats = {
-    text: () => formatComparisonAsText({ images, comparisonResults }),
-    table: () => formatComparisonAsTsv({ comparisonResults }),
+    text: () => formatComparisonAsText({ images, comparisonResults, requestsPerDay }),
+    table: () => formatComparisonAsTsv({ comparisonResults, requestsPerDay }),
   };
 
   if (comparisonResults.length === 0) {
@@ -82,6 +84,7 @@ export default function ComparisonTable() {
           </TableBody>
         </Table>
       </TableContainer>
+      <CostProjection />
     </Box>
   );
 }

--- a/src/stores/CalcStore.js
+++ b/src/stores/CalcStore.js
@@ -4,8 +4,14 @@ export const calcStore = (set, get) => ({
   imageResults: [],
   totalTokens: null,
   totalCost: null,
+  requestsPerDay: 0,
 
   setModel: (model) => set({ model }),
+
+  setRequestsPerDay: (value) => {
+    const parsed = Number.parseInt(value, 10);
+    set({ requestsPerDay: Number.isFinite(parsed) && parsed > 0 ? parsed : 0 });
+  },
 
   addImage: (image) => set((state) => ({ images: [...state.images, image] })),
   updateImage: (index, field, value) => {

--- a/src/stores/CalcStore.js
+++ b/src/stores/CalcStore.js
@@ -9,7 +9,7 @@ export const calcStore = (set, get) => ({
   setModel: (model) => set({ model }),
 
   setRequestsPerDay: (value) => {
-    const parsed = Number.parseInt(value, 10);
+    const parsed = Math.trunc(Number(value));
     set({ requestsPerDay: Number.isFinite(parsed) && parsed > 0 ? parsed : 0 });
   },
 

--- a/src/utils/__tests__/formatResults.test.js
+++ b/src/utils/__tests__/formatResults.test.js
@@ -360,6 +360,38 @@ describe("formatResultsAsText", () => {
 
     expect(text).not.toContain("Cost Projection");
   });
+
+  it("excludes cost projection when totalCost is 0", () => {
+    const text = formatResultsAsText({
+      model: patchModel,
+      images: [{ width: 100, height: 100, multiplier: 1 }],
+      imageResults: [
+        {
+          resizedWidth: 100,
+          resizedHeight: 100,
+          tokenization: { type: "patch", totalPatches: 16, imageTokens: 0 },
+        },
+      ],
+      totalTokens: 0,
+      totalCost: "0",
+      requestsPerDay: 1000,
+    });
+
+    expect(text).not.toContain("Cost Projection");
+  });
+
+  it("excludes cost projection when totalCost is null", () => {
+    const text = formatResultsAsText({
+      model: patchModel,
+      images: [],
+      imageResults: [],
+      totalTokens: 0,
+      totalCost: null,
+      requestsPerDay: 500,
+    });
+
+    expect(text).not.toContain("Cost Projection");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/utils/__tests__/formatResults.test.js
+++ b/src/utils/__tests__/formatResults.test.js
@@ -319,6 +319,47 @@ describe("formatResultsAsText", () => {
     expect(text).toContain("Image 1:");
     expect(text).toContain("?x?, Qty 1");
   });
+
+  it("includes cost projection when requestsPerDay is set", () => {
+    const text = formatResultsAsText({
+      model: patchModel,
+      images: [{ width: 1024, height: 768, multiplier: 1 }],
+      imageResults: [
+        {
+          resizedWidth: 1024,
+          resizedHeight: 768,
+          tokenization: { type: "patch", totalPatches: 768, imageTokens: 768 },
+        },
+      ],
+      totalTokens: 768,
+      totalCost: "0.00192",
+      requestsPerDay: 1000,
+    });
+
+    expect(text).toContain("Cost Projection");
+    expect(text).toContain("Requests per day: 1,000");
+    expect(text).toContain("Daily:");
+    expect(text).toContain("Monthly (30 days):");
+  });
+
+  it("excludes cost projection when requestsPerDay is 0", () => {
+    const text = formatResultsAsText({
+      model: patchModel,
+      images: [{ width: 1024, height: 768, multiplier: 1 }],
+      imageResults: [
+        {
+          resizedWidth: 1024,
+          resizedHeight: 768,
+          tokenization: { type: "patch", totalPatches: 768, imageTokens: 768 },
+        },
+      ],
+      totalTokens: 768,
+      totalCost: "0.00192",
+      requestsPerDay: 0,
+    });
+
+    expect(text).not.toContain("Cost Projection");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -415,6 +456,27 @@ describe("formatResultsAsTsv", () => {
     const dataLines = tsv.split("\n").filter((l) => l.startsWith("1") || l.startsWith("2"));
     expect(dataLines).toHaveLength(1);
   });
+
+  it("includes projection rows when requestsPerDay is set", () => {
+    const tsv = formatResultsAsTsv({
+      model: patchModel,
+      images: [{ width: 1024, height: 768, multiplier: 1 }],
+      imageResults: [
+        {
+          resizedWidth: 1024,
+          resizedHeight: 768,
+          tokenization: { type: "patch", totalPatches: 768, imageTokens: 768 },
+        },
+      ],
+      totalTokens: 768,
+      totalCost: "0.00192",
+      requestsPerDay: 500,
+    });
+
+    expect(tsv).toContain("Requests/Day\t500");
+    expect(tsv).toContain("Daily Cost");
+    expect(tsv).toContain("Monthly Cost (30d)");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -478,6 +540,42 @@ describe("formatComparisonAsText", () => {
 
     expect(text).toContain("No comparison results.");
   });
+
+  it("includes cost projection when requestsPerDay is set", () => {
+    const text = formatComparisonAsText({
+      images: [{ width: 1024, height: 768, multiplier: 1 }],
+      comparisonResults: [
+        {
+          model: patchModel,
+          totalTokens: 768,
+          totalCost: "0.00192",
+          imageResults: [],
+        },
+      ],
+      requestsPerDay: 1000,
+    });
+
+    expect(text).toContain("Cost Projection (1,000 requests/day)");
+    expect(text).toContain("GPT-5.4 (Global): Daily");
+    expect(text).toContain("Monthly");
+  });
+
+  it("excludes cost projection when requestsPerDay is 0", () => {
+    const text = formatComparisonAsText({
+      images: [],
+      comparisonResults: [
+        {
+          model: patchModel,
+          totalTokens: 768,
+          totalCost: "0.00192",
+          imageResults: [],
+        },
+      ],
+      requestsPerDay: 0,
+    });
+
+    expect(text).not.toContain("Cost Projection");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -517,5 +615,42 @@ describe("formatComparisonAsTsv", () => {
     const tsv = formatComparisonAsTsv({ comparisonResults: [] });
     const lines = tsv.split("\n");
     expect(lines).toHaveLength(1); // header only
+  });
+
+  it("adds daily and monthly columns when requestsPerDay is set", () => {
+    const tsv = formatComparisonAsTsv({
+      comparisonResults: [
+        {
+          model: patchModel,
+          totalTokens: 768,
+          totalCost: "0.00192",
+          imageResults: [],
+        },
+      ],
+      requestsPerDay: 500,
+    });
+
+    const lines = tsv.split("\n");
+    expect(lines[0]).toContain("Daily Cost");
+    expect(lines[0]).toContain("Monthly Cost (30d)");
+    expect(lines[1].split("\t").length).toBe(8);
+  });
+
+  it("omits projection columns when requestsPerDay is 0", () => {
+    const tsv = formatComparisonAsTsv({
+      comparisonResults: [
+        {
+          model: patchModel,
+          totalTokens: 768,
+          totalCost: "0.00192",
+          imageResults: [],
+        },
+      ],
+      requestsPerDay: 0,
+    });
+
+    const lines = tsv.split("\n");
+    expect(lines[0]).not.toContain("Daily Cost");
+    expect(lines[1].split("\t").length).toBe(6);
   });
 });

--- a/src/utils/formatResults.js
+++ b/src/utils/formatResults.js
@@ -11,7 +11,7 @@ const currencyFormat = new Intl.NumberFormat(undefined, {
  * Build a plain-text summary of the calculation results suitable for
  * pasting into documents, messages, or cost analyses.
  *
- * @param {{ model: object, images: object[], imageResults: object[], totalTokens: number, totalCost: string|number }} params
+ * @param {{ model: object, images: object[], imageResults: object[], totalTokens: number, totalCost: string|number, requestsPerDay?: number }} params
  * @returns {string}
  */
 export function formatResultsAsText({
@@ -85,9 +85,9 @@ export function formatResultsAsText({
   lines.push(`Total tokens: ${formattedTokens}`);
   lines.push(`Estimated cost: ${formattedCost} (${costRate})`);
 
-  // Cost projection (only when non-zero)
+  // Cost projection (only when requestsPerDay > 0 and cost is positive)
   const unitCost = Number.parseFloat(totalCost ?? "0");
-  if (requestsPerDay > 0 && Number.isFinite(unitCost)) {
+  if (requestsPerDay > 0 && Number.isFinite(unitCost) && unitCost > 0) {
     const dailyCost = unitCost * requestsPerDay;
     const monthlyCost = dailyCost * 30;
     lines.push("");
@@ -104,7 +104,7 @@ export function formatResultsAsText({
  * Build a plain-text comparison table of multiple model results suitable
  * for pasting into documents, messages, or cost analyses.
  *
- * @param {{ images: object[], comparisonResults: { model: object, totalTokens: number, totalCost: string|number, imageResults: object[] }[] }} params
+ * @param {{ images: object[], comparisonResults: { model: object, totalTokens: number, totalCost: string|number, imageResults: object[] }[], requestsPerDay?: number }} params
  * @returns {string}
  */
 export function formatComparisonAsText({ images, comparisonResults, requestsPerDay }) {
@@ -193,7 +193,7 @@ export function formatComparisonAsText({ images, comparisonResults, requestsPerD
     lines.push(`Cost Projection (${numberFormat.format(requestsPerDay)} requests/day)`);
     for (const r of comparisonResults) {
       const unitCost = Number.parseFloat(r.totalCost ?? "0");
-      if (!Number.isFinite(unitCost)) continue;
+      if (!Number.isFinite(unitCost) || unitCost <= 0) continue;
       const daily = unitCost * requestsPerDay;
       const monthly = daily * 30;
       lines.push(
@@ -209,7 +209,7 @@ export function formatComparisonAsText({ images, comparisonResults, requestsPerD
  * Build a TSV (tab-separated values) version of single-model results
  * that pastes cleanly into spreadsheet applications.
  *
- * @param {{ model: object, images: object[], imageResults: object[], totalTokens: number, totalCost: string|number }} params
+ * @param {{ model: object, images: object[], imageResults: object[], totalTokens: number, totalCost: string|number, requestsPerDay?: number }} params
  * @returns {string}
  */
 export function formatResultsAsTsv({
@@ -267,9 +267,9 @@ export function formatResultsAsTsv({
     rows.push(["Model", model.name].join("\t"));
   }
 
-  // Cost projection (only when non-zero)
+  // Cost projection (only when requestsPerDay > 0 and cost is positive)
   const unitCost = Number.parseFloat(totalCost ?? "0");
-  if (requestsPerDay > 0 && Number.isFinite(unitCost)) {
+  if (requestsPerDay > 0 && Number.isFinite(unitCost) && unitCost > 0) {
     const dailyCost = unitCost * requestsPerDay;
     const monthlyCost = dailyCost * 30;
     rows.push("");
@@ -285,7 +285,7 @@ export function formatResultsAsTsv({
  * Build a TSV (tab-separated values) version of comparison results
  * that pastes cleanly into spreadsheet applications.
  *
- * @param {{ comparisonResults: { model: object, totalTokens: number, totalCost: string|number, imageResults: object[] }[] }} params
+ * @param {{ comparisonResults: { model: object, totalTokens: number, totalCost: string|number, imageResults: object[] }[], requestsPerDay?: number }} params
  * @returns {string}
  */
 export function formatComparisonAsTsv({ comparisonResults, requestsPerDay }) {
@@ -314,9 +314,13 @@ export function formatComparisonAsTsv({ comparisonResults, requestsPerDay }) {
     const cols = [name, tokenType, tokens, cost, rate, retirement];
     if (hasProjection) {
       const unitCost = Number.parseFloat(r.totalCost ?? "0");
-      const daily = Number.isFinite(unitCost) ? unitCost * requestsPerDay : 0;
+      const valid = Number.isFinite(unitCost) && unitCost > 0;
+      const daily = valid ? unitCost * requestsPerDay : 0;
       const monthly = daily * 30;
-      cols.push(currencyFormat.format(daily), currencyFormat.format(monthly));
+      cols.push(
+        valid ? currencyFormat.format(daily) : "-",
+        valid ? currencyFormat.format(monthly) : "-",
+      );
     }
     rows.push(cols.join("\t"));
   }

--- a/src/utils/formatResults.js
+++ b/src/utils/formatResults.js
@@ -20,6 +20,7 @@ export function formatResultsAsText({
   imageResults,
   totalTokens,
   totalCost,
+  requestsPerDay,
 }) {
   const isPatch = model?.tokenizationType === "patch";
   const lines = ["Azure OpenAI Image Token Calculator"];
@@ -84,6 +85,18 @@ export function formatResultsAsText({
   lines.push(`Total tokens: ${formattedTokens}`);
   lines.push(`Estimated cost: ${formattedCost} (${costRate})`);
 
+  // Cost projection (only when non-zero)
+  const unitCost = Number.parseFloat(totalCost ?? "0");
+  if (requestsPerDay > 0 && Number.isFinite(unitCost)) {
+    const dailyCost = unitCost * requestsPerDay;
+    const monthlyCost = dailyCost * 30;
+    lines.push("");
+    lines.push("Cost Projection");
+    lines.push(`Requests per day: ${numberFormat.format(requestsPerDay)}`);
+    lines.push(`Daily: ${currencyFormat.format(dailyCost)}`);
+    lines.push(`Monthly (30 days): ${currencyFormat.format(monthlyCost)}`);
+  }
+
   return lines.join("\n");
 }
 
@@ -94,7 +107,7 @@ export function formatResultsAsText({
  * @param {{ images: object[], comparisonResults: { model: object, totalTokens: number, totalCost: string|number, imageResults: object[] }[] }} params
  * @returns {string}
  */
-export function formatComparisonAsText({ images, comparisonResults }) {
+export function formatComparisonAsText({ images, comparisonResults, requestsPerDay }) {
   const lines = [
     "Azure OpenAI Image Token Calculator - Model Comparison",
     "",
@@ -174,6 +187,21 @@ export function formatComparisonAsText({ images, comparisonResults }) {
     }
   }
 
+  // Cost projection (only when non-zero)
+  if (requestsPerDay > 0) {
+    lines.push("");
+    lines.push(`Cost Projection (${numberFormat.format(requestsPerDay)} requests/day)`);
+    for (const r of comparisonResults) {
+      const unitCost = Number.parseFloat(r.totalCost ?? "0");
+      if (!Number.isFinite(unitCost)) continue;
+      const daily = unitCost * requestsPerDay;
+      const monthly = daily * 30;
+      lines.push(
+        `  ${r.model?.name ?? "Unknown"}: Daily ${currencyFormat.format(daily)} | Monthly ${currencyFormat.format(monthly)}`,
+      );
+    }
+  }
+
   return lines.join("\n");
 }
 
@@ -190,6 +218,7 @@ export function formatResultsAsTsv({
   imageResults,
   totalTokens,
   totalCost,
+  requestsPerDay,
 }) {
   const isPatch = model?.tokenizationType === "patch";
   const unitLabel = isPatch ? "Patches" : "Tiles";
@@ -238,6 +267,17 @@ export function formatResultsAsTsv({
     rows.push(["Model", model.name].join("\t"));
   }
 
+  // Cost projection (only when non-zero)
+  const unitCost = Number.parseFloat(totalCost ?? "0");
+  if (requestsPerDay > 0 && Number.isFinite(unitCost)) {
+    const dailyCost = unitCost * requestsPerDay;
+    const monthlyCost = dailyCost * 30;
+    rows.push("");
+    rows.push(["Requests/Day", requestsPerDay].join("\t"));
+    rows.push(["Daily Cost", currencyFormat.format(dailyCost)].join("\t"));
+    rows.push(["Monthly Cost (30d)", currencyFormat.format(monthlyCost)].join("\t"));
+  }
+
   return rows.join("\n");
 }
 
@@ -248,12 +288,15 @@ export function formatResultsAsTsv({
  * @param {{ comparisonResults: { model: object, totalTokens: number, totalCost: string|number, imageResults: object[] }[] }} params
  * @returns {string}
  */
-export function formatComparisonAsTsv({ comparisonResults }) {
+export function formatComparisonAsTsv({ comparisonResults, requestsPerDay }) {
+  const hasProjection = requestsPerDay > 0;
   const rows = [];
 
-  rows.push(
-    ["Model", "Type", "Total Tokens", "Estimated Cost", "Rate", "Retirement"].join("\t"),
-  );
+  const headers = ["Model", "Type", "Total Tokens", "Estimated Cost", "Rate", "Retirement"];
+  if (hasProjection) {
+    headers.push("Daily Cost", "Monthly Cost (30d)");
+  }
+  rows.push(headers.join("\t"));
 
   if (!comparisonResults || comparisonResults.length === 0) {
     return rows.join("\n");
@@ -268,7 +311,14 @@ export function formatComparisonAsTsv({ comparisonResults }) {
     const rate = `$${r.model?.costPerMillionTokens ?? "?"}/1M tokens`;
     const retirement = r.model?.retirementDate ?? "";
 
-    rows.push([name, tokenType, tokens, cost, rate, retirement].join("\t"));
+    const cols = [name, tokenType, tokens, cost, rate, retirement];
+    if (hasProjection) {
+      const unitCost = Number.parseFloat(r.totalCost ?? "0");
+      const daily = Number.isFinite(unitCost) ? unitCost * requestsPerDay : 0;
+      const monthly = daily * 30;
+      cols.push(currencyFormat.format(daily), currencyFormat.format(monthly));
+    }
+    rows.push(cols.join("\t"));
   }
 
   return rows.join("\n");


### PR DESCRIPTION
This pull request introduces a new "Cost Projection" feature to the calculator, allowing users to estimate daily and monthly costs based on a configurable number of requests per day. The feature is integrated into both single-model and comparison workflows, is reflected in the UI, and is included in exported text and TSV formats. The changes also add corresponding unit tests to ensure correct behavior.

**Cost Projection Feature:**

* Added a new `CostProjection` component that lets users enter "requests per day" and view projected daily and monthly costs for both single-model and comparison modes. (`src/components/calculator/CostProjection.jsx`)
* Integrated the `CostProjection` component into the main calculator output and comparison table UIs, so projections are always visible when relevant. (`src/components/calculator/CalculatorOutput.jsx`, `src/components/calculator/comparison/ComparisonTable.jsx`) [[1]](diffhunk://#diff-25677943c5d70871ccc1e032a155f9a30d60f6068919bfd7b99887bf6bec8bceR25) [[2]](diffhunk://#diff-25677943c5d70871ccc1e032a155f9a30d60f6068919bfd7b99887bf6bec8bceR105) [[3]](diffhunk://#diff-3fe172f505ef7ee3092f68b34c08f41891dfec22096251eab2640884c3363b6fR18-R32) [[4]](diffhunk://#diff-3fe172f505ef7ee3092f68b34c08f41891dfec22096251eab2640884c3363b6fR87)

**State Management:**

* Updated the calculator store to include `requestsPerDay` and a setter, ensuring the value is shared across components and persists as part of the app state. (`src/stores/CalcStore.js`)

**Export and Formatting Enhancements:**

* Modified formatting utilities to include cost projections in text and TSV exports when `requestsPerDay` is set, for both single-model and comparison exports. (`src/utils/formatResults.js`) [[1]](diffhunk://#diff-d8af51e17eec0ecc4e6cd1f700d712b9e5b9660bdbb403e32f89945e232d4fffR23) [[2]](diffhunk://#diff-d8af51e17eec0ecc4e6cd1f700d712b9e5b9660bdbb403e32f89945e232d4fffR88-R99) [[3]](diffhunk://#diff-d8af51e17eec0ecc4e6cd1f700d712b9e5b9660bdbb403e32f89945e232d4fffL97-R110) [[4]](diffhunk://#diff-d8af51e17eec0ecc4e6cd1f700d712b9e5b9660bdbb403e32f89945e232d4fffR190-R204) [[5]](diffhunk://#diff-d8af51e17eec0ecc4e6cd1f700d712b9e5b9660bdbb403e32f89945e232d4fffR221) [[6]](diffhunk://#diff-d8af51e17eec0ecc4e6cd1f700d712b9e5b9660bdbb403e32f89945e232d4fffR270-R280) [[7]](diffhunk://#diff-d8af51e17eec0ecc4e6cd1f700d712b9e5b9660bdbb403e32f89945e232d4fffL251-R299) [[8]](diffhunk://#diff-d8af51e17eec0ecc4e6cd1f700d712b9e5b9660bdbb403e32f89945e232d4fffL271-R321)
* Updated UI logic so export buttons include the projection data as appropriate. (`src/components/calculator/CalculatorOutput.jsx`, `src/components/calculator/comparison/ComparisonTable.jsx`) [[1]](diffhunk://#diff-25677943c5d70871ccc1e032a155f9a30d60f6068919bfd7b99887bf6bec8bceR34-R40) [[2]](diffhunk://#diff-3fe172f505ef7ee3092f68b34c08f41891dfec22096251eab2640884c3363b6fR18-R32)

**Testing:**

* Added comprehensive unit tests to verify that cost projections are correctly included or omitted in exported text and TSV outputs depending on the value of `requestsPerDay`. (`src/utils/__tests__/formatResults.test.js`) [[1]](diffhunk://#diff-0ad0284476285541932e8ed4d0253e5e3c11616f7acf31ce693b45e17f4ee7fcR322-R362) [[2]](diffhunk://#diff-0ad0284476285541932e8ed4d0253e5e3c11616f7acf31ce693b45e17f4ee7fcR459-R479) [[3]](diffhunk://#diff-0ad0284476285541932e8ed4d0253e5e3c11616f7acf31ce693b45e17f4ee7fcR543-R578) [[4]](diffhunk://#diff-0ad0284476285541932e8ed4d0253e5e3c11616f7acf31ce693b45e17f4ee7fcR619-R655)